### PR TITLE
feat(runtime): Add ability to push events to the event queue from WASM

### DIFF
--- a/node/src/app/mod.rs
+++ b/node/src/app/mod.rs
@@ -4,10 +4,12 @@ use actix::prelude::*;
 use parking_lot::RwLock;
 use seda_config::{ChainConfigs, NodeConfig};
 use seda_runtime::HostAdapter;
+use seda_runtime_sdk::events::EventId;
 use tracing::info;
 
 use crate::{
-    event_queue::{EventId, EventQueue},
+    event_queue::EventQueue,
+    host::{Host, SetAppAddress},
     rpc::JsonRpcServer,
     runtime_job::RuntimeWorker,
 };
@@ -57,6 +59,11 @@ impl<HA: HostAdapter> Actor for App<HA> {
         info!("Node starting... \n{}", banner);
 
         info!("Starting Job Manager...");
+        let app_address = ctx.address();
+
+        let host = Host::from_registry();
+        host.do_send(SetAppAddress { address: app_address });
+
         ctx.notify(job_manager::StartJobManager);
     }
 

--- a/node/src/errors.rs
+++ b/node/src/errors.rs
@@ -14,6 +14,8 @@ pub enum NodeError {
     RuqliteError(#[from] rusqlite::Error),
     #[error("Chain Adapter Error: {0}")]
     ChainAdapterError(#[from] seda_chains::ChainAdapterError),
+    #[error("Missing app actor address in host adapter, was the node booted?")]
+    MissingAppActorAddress,
 }
 
 pub type Result<T, E = NodeError> = core::result::Result<T, E>;

--- a/node/src/event_queue.rs
+++ b/node/src/event_queue.rs
@@ -1,19 +1,5 @@
+use seda_runtime_sdk::events::Event;
 use serde::{Deserialize, Serialize};
-
-pub type EventId = String;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum EventData {
-    // Tick types
-    ChainTick,
-    CliCall(Vec<String>),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Event {
-    pub id:   EventId,
-    pub data: EventData,
-}
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct EventQueue {

--- a/node/src/event_queue_handler.rs
+++ b/node/src/event_queue_handler.rs
@@ -1,8 +1,9 @@
 use actix::{Handler, Message};
 use seda_runtime::HostAdapter;
+use seda_runtime_sdk::events::Event;
 use serde::{Deserialize, Serialize};
 
-use crate::{app::App, event_queue::Event};
+use crate::app::App;
 
 #[derive(Message, Serialize, Deserialize)]
 #[rtype(result = "()")]

--- a/node/src/event_queue_test.rs
+++ b/node/src/event_queue_test.rs
@@ -1,4 +1,6 @@
-use crate::event_queue::{Event, EventData, EventQueue};
+use seda_runtime_sdk::events::{Event, EventData};
+
+use crate::event_queue::EventQueue;
 
 #[test]
 fn add_item_to_event_queue() {

--- a/node/src/host/chain_call.rs
+++ b/node/src/host/chain_call.rs
@@ -1,6 +1,7 @@
 use actix::prelude::*;
 use seda_chains::{chain, Client};
 use seda_config::{ChainConfigs, NodeConfig};
+use seda_runtime::HostAdapter;
 use seda_runtime_sdk::Chain;
 
 use crate::{Host, Result};
@@ -17,7 +18,7 @@ pub struct ChainCall {
     pub chains_config: ChainConfigs,
 }
 
-impl Handler<ChainCall> for Host {
+impl<HA: HostAdapter> Handler<ChainCall> for Host<HA> {
     type Result = ResponseActFuture<Self, Result<Vec<u8>>>;
 
     fn handle(&mut self, msg: ChainCall, _ctx: &mut Self::Context) -> Self::Result {

--- a/node/src/host/chain_view.rs
+++ b/node/src/host/chain_view.rs
@@ -1,5 +1,6 @@
 use actix::prelude::*;
 use seda_chains::{chain, Client};
+use seda_runtime::HostAdapter;
 use seda_runtime_sdk::Chain;
 
 use crate::{Host, Result};
@@ -14,7 +15,7 @@ pub struct ChainView {
     pub client:      Client,
 }
 
-impl Handler<ChainView> for Host {
+impl<HA: HostAdapter> Handler<ChainView> for Host<HA> {
     type Result = ResponseActFuture<Self, Result<String>>;
 
     fn handle(&mut self, msg: ChainView, _ctx: &mut Self::Context) -> Self::Result {

--- a/node/src/host/db_get.rs
+++ b/node/src/host/db_get.rs
@@ -1,4 +1,5 @@
 use actix::prelude::*;
+use seda_runtime::HostAdapter;
 use serde::{Deserialize, Serialize};
 
 use crate::{Host, NodeError, Result};
@@ -9,7 +10,7 @@ pub struct DatabaseGet {
     pub key: String,
 }
 
-impl Handler<DatabaseGet> for Host {
+impl<HA: HostAdapter> Handler<DatabaseGet> for Host<HA> {
     type Result = ResponseActFuture<Self, Result<Option<String>>>;
 
     fn handle(&mut self, msg: DatabaseGet, _ctx: &mut Self::Context) -> Self::Result {

--- a/node/src/host/db_set.rs
+++ b/node/src/host/db_set.rs
@@ -1,5 +1,6 @@
 use actix::prelude::*;
 use rusqlite::params;
+use seda_runtime::HostAdapter;
 use serde::{Deserialize, Serialize};
 
 use crate::{Host, NodeError, Result};
@@ -11,7 +12,7 @@ pub struct DatabaseSet {
     pub value: String,
 }
 
-impl Handler<DatabaseSet> for Host {
+impl<HA: HostAdapter> Handler<DatabaseSet> for Host<HA> {
     type Result = ResponseActFuture<Self, Result<()>>;
 
     fn handle(&mut self, msg: DatabaseSet, _ctx: &mut Self::Context) -> Self::Result {

--- a/node/src/host/http_fetch.rs
+++ b/node/src/host/http_fetch.rs
@@ -1,4 +1,5 @@
 use actix::prelude::*;
+use seda_runtime::HostAdapter;
 use serde::{Deserialize, Serialize};
 
 use super::Host;
@@ -9,7 +10,7 @@ pub struct HttpFetch {
     pub url: String,
 }
 
-impl Handler<HttpFetch> for Host {
+impl<HA: HostAdapter> Handler<HttpFetch> for Host<HA> {
     type Result = ResponseActFuture<Self, String>;
 
     fn handle(&mut self, msg: HttpFetch, _ctx: &mut Self::Context) -> Self::Result {

--- a/node/src/host/set_app_addr.rs
+++ b/node/src/host/set_app_addr.rs
@@ -1,0 +1,22 @@
+use actix::{Addr, Handler, Message};
+use seda_runtime::HostAdapter;
+
+use super::Host;
+use crate::app::App;
+
+/// We need to set the app address in order to access the event queue
+/// The VM has the ability to add events to this queue (resolve dr, resolve
+/// block, etc)
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct SetAppAddress<HA: HostAdapter> {
+    pub address: Addr<App<HA>>,
+}
+
+impl<HA: HostAdapter> Handler<SetAppAddress<HA>> for Host<HA> {
+    type Result = ();
+
+    fn handle(&mut self, msg: SetAppAddress<HA>, _ctx: &mut Self::Context) -> Self::Result {
+        self.app_actor_addr = Some(msg.address);
+    }
+}

--- a/node/src/host/trigger_event.rs
+++ b/node/src/host/trigger_event.rs
@@ -1,0 +1,29 @@
+//! Communication layer between App & Host adapter
+//! We send a message to trigger an event to the host actor
+//! which redirects the message to the app actor
+use actix::prelude::*;
+use seda_runtime::HostAdapter;
+use seda_runtime_sdk::events::Event;
+use serde::{Deserialize, Serialize};
+
+use crate::{event_queue_handler::AddEventToQueue, Host, NodeError::MissingAppActorAddress, Result};
+
+#[derive(Message, Serialize, Deserialize)]
+#[rtype(result = "Result<()>")]
+pub struct TriggerEvent {
+    pub event: Event,
+}
+
+impl<HA: HostAdapter> Handler<TriggerEvent> for Host<HA> {
+    type Result = Result<()>;
+
+    fn handle(&mut self, msg: TriggerEvent, _ctx: &mut Self::Context) -> Self::Result {
+        if let Some(app_actor) = self.app_actor_addr.clone() {
+            app_actor.do_send(AddEventToQueue { event: msg.event });
+
+            return Ok(());
+        }
+
+        Err(MissingAppActorAddress)
+    }
+}

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -5,12 +5,10 @@ use jsonrpsee::{
     server::{ServerBuilder, ServerHandle},
 };
 use seda_runtime::HostAdapter;
+use seda_runtime_sdk::events::{Event, EventData};
 use tracing::debug;
 
-use crate::{
-    event_queue::{Event, EventData},
-    runtime_job::{RuntimeJob, RuntimeWorker},
-};
+use crate::runtime_job::{RuntimeJob, RuntimeWorker};
 
 #[rpc(server)]
 pub trait Rpc {

--- a/node/src/runtime_job.rs
+++ b/node/src/runtime_job.rs
@@ -4,9 +4,8 @@ use actix::{prelude::*, Handler, Message};
 use parking_lot::Mutex;
 use seda_config::{ChainConfigs, NodeConfig};
 use seda_runtime::{HostAdapter, InMemory, Result, RunnableRuntime, Runtime, VmConfig, VmResult};
+use seda_runtime_sdk::events::{Event, EventData};
 use tracing::info;
-
-use crate::event_queue::{Event, EventData};
 
 #[derive(MessageResponse)]
 pub struct RuntimeJobResult {

--- a/runtime/core/src/host_adapter.rs
+++ b/runtime/core/src/host_adapter.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use seda_chains::Client;
 use seda_config::{ChainConfigs, NodeConfig};
-use seda_runtime_sdk::Chain;
+use seda_runtime_sdk::{events::Event, Chain};
 
 #[async_trait::async_trait]
 pub trait HostAdapter: Send + Sync + Unpin + 'static {
@@ -35,4 +35,6 @@ pub trait HostAdapter: Send + Sync + Unpin + 'static {
         method_name: &str,
         args: Vec<u8>,
     ) -> Result<String, Self::Error>;
+
+    async fn trigger_event(&self, event: Event) -> Result<(), Self::Error>;
 }

--- a/runtime/core/src/runtime.rs
+++ b/runtime/core/src/runtime.rs
@@ -215,6 +215,14 @@ impl<HA: HostAdapter> RunnableRuntime for Runtime<HA> {
 
                         promise_queue_mut.queue[index].status = PromiseStatus::Fulfilled(resp);
                     }
+                    PromiseAction::TriggerEvent(trigger_event_action) => {
+                        self.host_adapter
+                            .trigger_event(trigger_event_action.event.clone())
+                            .await
+                            .map_err(|e| RuntimeError::NodeError(e.to_string()))?;
+
+                        promise_queue_mut.queue[index].status = PromiseStatus::Fulfilled(vec![]);
+                    }
                 }
             }
         }

--- a/runtime/core/src/test_host.rs
+++ b/runtime/core/src/test_host.rs
@@ -4,7 +4,7 @@ use futures::lock::Mutex;
 use lazy_static::lazy_static;
 use seda_chains::{chain, AnotherChain, ChainAdapterTrait, Client, NearChain};
 use seda_config::{ChainConfigs, NodeConfig};
-use seda_runtime_sdk::Chain;
+use seda_runtime_sdk::{events::Event, Chain};
 
 use crate::{HostAdapter, Result, RuntimeError};
 
@@ -88,5 +88,9 @@ impl HostAdapter for RuntimeTestAdapter {
         .await?;
         let client = self.select_client_from_chain(chain);
         Ok(chain::send_tx(chain, client, &signed_txn).await?)
+    }
+
+    async fn trigger_event(&self, event: Event) -> Result<()> {
+        Ok(())
     }
 }

--- a/runtime/sdk/src/events.rs
+++ b/runtime/sdk/src/events.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+pub type EventId = String;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum EventData {
+    // Tick types
+    ChainTick,
+    CliCall(Vec<String>),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Event {
+    pub id:   EventId,
+    pub data: EventData,
+}

--- a/runtime/sdk/src/lib.rs
+++ b/runtime/sdk/src/lib.rs
@@ -7,6 +7,8 @@ mod promises;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+pub mod events;
+
 pub use promises::{
     CallSelfAction,
     ChainCallAction,
@@ -17,4 +19,5 @@ pub use promises::{
     Promise,
     PromiseAction,
     PromiseStatus,
+    TriggerEventAction,
 };

--- a/runtime/sdk/src/promises/actions.rs
+++ b/runtime/sdk/src/promises/actions.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::Chain;
+use crate::{events::Event, Chain};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PromiseAction {
@@ -10,6 +10,7 @@ pub enum PromiseAction {
     Http(HttpAction),
     ChainView(ChainViewAction),
     ChainCall(ChainCallAction),
+    TriggerEvent(TriggerEventAction),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -50,4 +51,9 @@ pub struct ChainCallAction {
     pub method_name: String,
     pub args:        Vec<u8>,
     pub deposit:     String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TriggerEventAction {
+    pub event: Event,
 }

--- a/runtime/sdk/src/wasm/execution.rs
+++ b/runtime/sdk/src/wasm/execution.rs
@@ -1,4 +1,5 @@
-use super::raw;
+use super::{raw, Promise};
+use crate::{events::Event, PromiseAction, TriggerEventAction};
 
 pub fn execution_result(result: Vec<u8>) {
     let result_length = result.len() as i32;
@@ -6,4 +7,10 @@ pub fn execution_result(result: Vec<u8>) {
     unsafe {
         raw::execution_result(result.as_ptr(), result_length);
     }
+}
+
+/// Triggers an event on the host node
+/// Allows you to resolve data requests, sign blocks but at a later stage
+pub fn trigger_event(event: Event) -> Promise {
+    Promise::new(PromiseAction::TriggerEvent(TriggerEventAction { event }))
 }

--- a/wasm/cli/src/main.rs
+++ b/wasm/cli/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use seda_runtime_sdk::{
-    wasm::{call_self, chain_call, chain_view, db_set, http_fetch, log, Promise},
+    events::{Event, EventData},
+    wasm::{call_self, chain_call, chain_view, db_set, http_fetch, log, trigger_event, Promise},
     Chain,
     PromiseStatus,
 };
@@ -39,7 +40,6 @@ enum Commands {
 fn main() {
     let options = Options::parse();
     log!(seda_runtime_sdk::Level::Debug, "options: {options:?}");
-    println!("Hello Wasm CLI!");
 
     if let Some(command) = options.command {
         match command {
@@ -48,6 +48,11 @@ fn main() {
                 http_fetch(&url).start().then(call_self("http_fetch_result", vec![]));
             }
             Commands::Hello => {
+                trigger_event(Event {
+                    id:   "test".to_string(),
+                    data: EventData::ChainTick,
+                })
+                .start();
                 println!("Hello World from inside wasm");
             }
             // TODO how to remove double near specification here?


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Some tasks require to be executed by a different WASM binary, or in a different VM environment (Like DataRequests, which should have limited capabilities). These decisions on what to do when are decided by the WASM binary, but it needs to be able to trigger events to access these capabilities. This PR introduces trigger_event as a new PromiseAction to enable this.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Added a trigger_event to the PromiseAction's to enable event pushing to the event queue. I had to include the app actor inside the host actor to let it be able to send messages to the app actor.
At startup the app sends it's own address to the host actor so it can be used later.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Run the node normally and trigger the command: `make run-build-all -- -c near cli hello` this will call the node first with the hello world and push an event to the queue (ChainTick). You can see the node executing the VM again with this event.
