### PR TITLE
refactor: clean up chain trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3984,18 +3984,14 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "borsh",
- "jsonrpsee-types",
  "near-crypto 0.15.0",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-primitives 0.15.0",
  "seda-config",
  "seda-runtime-sdk",
- "serde",
- "serde_json",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/chains/Cargo.toml
+++ b/chains/Cargo.toml
@@ -6,15 +6,11 @@ edition = "2021"
 [dependencies]
 async-trait = { workspace = true }
 borsh = { workspace = true }
-jsonrpsee-types = { workspace = true }
 near-jsonrpc-client = { workspace = true }
 near-jsonrpc-primitives = { workspace = true }
 near-primitives = { workspace = true }
 tokio = { workspace = true }
 seda-config = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 seda-runtime-sdk = { workspace = true }
 near-crypto = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }

--- a/chains/src/another_chain.rs
+++ b/chains/src/another_chain.rs
@@ -10,11 +10,11 @@ pub struct AnotherChain;
 
 #[async_trait::async_trait]
 impl ChainAdapterTrait for AnotherChain {
-    type Client = ();
+    type Client = Arc<()>;
     type Config = AnotherConfig;
 
     fn new_client(_config: &Self::Config) -> Result<Self::Client> {
-        Ok(())
+        Ok(Arc::new(()))
     }
 
     async fn construct_signed_tx(
@@ -30,20 +30,15 @@ impl ChainAdapterTrait for AnotherChain {
         unimplemented!()
     }
 
-    async fn sign_tx(_client: Arc<Self::Client>, _tx_params: TransactionParams) -> Result<Vec<u8>> {
+    async fn sign_tx(_client: Self::Client, _tx_params: TransactionParams) -> Result<Vec<u8>> {
         unimplemented!()
     }
 
-    async fn send_tx(_client: Arc<Self::Client>, _signed_tx: &[u8]) -> Result<Vec<u8>> {
+    async fn send_tx(_client: Self::Client, _signed_tx: &[u8]) -> Result<Vec<u8>> {
         unimplemented!()
     }
 
-    async fn view(
-        _client: Arc<Self::Client>,
-        _contract_id: &str,
-        _method_name: &str,
-        _args: Vec<u8>,
-    ) -> Result<Vec<u8>> {
+    async fn view(_client: Self::Client, _contract_id: &str, _method_name: &str, _args: Vec<u8>) -> Result<Vec<u8>> {
         unimplemented!()
     }
 }

--- a/chains/src/chain_adapter_trait.rs
+++ b/chains/src/chain_adapter_trait.rs
@@ -1,10 +1,6 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
-use jsonrpsee_types::Params;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
-use crate::{ChainAdapterError, Result};
+use crate::Result;
 
 pub struct TransactionParams {
     pub signer_acc_str: String,
@@ -16,27 +12,12 @@ pub struct TransactionParams {
     pub deposit:        u128,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename = "")]
-pub struct NodeIds {
-    pub contract_id: String,
-    pub node_id:     u64,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct NodeDetails {
-    pub contract_id: String,
-    pub limit:       u64,
-    pub offset:      u64,
-}
-
-// TODO once rpc becomes a trait need to replace params type.
 #[async_trait::async_trait]
 pub trait ChainAdapterTrait: Debug + Send + Sync + 'static {
-    /// The Config fields for the adapter specific implementation.
-    type Config: Send + Sync;
     /// The Client type for the adapter specific implementation.
     type Client: Send + Sync + 'static;
+    /// The Config fields for the adapter specific implementation.
+    type Config: Send + Sync;
 
     /// Returns an new instance of the client given the server address.
     fn new_client(config: &Self::Config) -> Result<Self::Client>;
@@ -53,83 +34,11 @@ pub trait ChainAdapterTrait: Debug + Send + Sync + 'static {
         deposit: u128,
         server_url: &str,
     ) -> Result<Vec<u8>>;
-    /// Default trait function that calls sign and send specific
-    /// implementations.
-    async fn sign_and_send_tx(client: Arc<Self::Client>, tx_params: TransactionParams) -> Result<Vec<u8>> {
-        let signed_tx = Self::sign_tx(client.clone(), tx_params).await?;
-        Self::send_tx(client, &signed_tx).await
-    }
-
     /// To sign a transaction for the adapter specific implementation.
-    async fn sign_tx(client: Arc<Self::Client>, tx_params: TransactionParams) -> Result<Vec<u8>>;
+    async fn sign_tx(client: Self::Client, tx_params: TransactionParams) -> Result<Vec<u8>>;
 
     /// To send a transaction for the adapter specific implementation.
-    async fn send_tx(client: Arc<Self::Client>, signed_tx: &[u8]) -> Result<Vec<u8>>;
+    async fn send_tx(client: Self::Client, signed_tx: &[u8]) -> Result<Vec<u8>>;
     /// To view for the adapter specific implementation.
-    async fn view(client: Arc<Self::Client>, contract_id: &str, method_name: &str, args: Vec<u8>) -> Result<Vec<u8>>;
-    /// Default trait function to get the node owner.
-    async fn get_node_owner(client: Arc<Self::Client>, params: Params<'_>) -> Result<Vec<u8>> {
-        let method_name = "get_node_owner";
-        let params = params
-            .one::<NodeIds>()
-            .map_err(|e| ChainAdapterError::BadParams(format!("{method_name}: {e}")))?;
-
-        let args = json!({"node_id": params.node_id.to_string()}).to_string().into_bytes();
-
-        Self::view(client, &params.contract_id.to_string(), method_name, args).await
-    }
-
-    /// Default trait function to get the node socket address.
-    async fn get_node_socket_address(client: Arc<Self::Client>, params: Params<'_>) -> Result<Vec<u8>> {
-        let method_name = "get_node_socket_address";
-        let params = params
-            .one::<NodeIds>()
-            .map_err(|_| ChainAdapterError::BadParams(method_name.to_string()))?;
-
-        let args = json!({"node_id": params.node_id.to_string()}).to_string().into_bytes();
-
-        Self::view(client, &params.contract_id.to_string(), method_name, args).await
-    }
-
-    /// Default trait function to get the nodes.
-    async fn get_nodes(client: Arc<Self::Client>, params: Params<'_>) -> Result<Vec<u8>> {
-        let method_name = "get_nodes";
-
-        let params = params
-            .one::<NodeDetails>()
-            .map_err(|_| ChainAdapterError::BadParams(method_name.to_string()))?;
-
-        let args = json!({"limit": params.limit.to_string(), "offset": params.offset.to_string()})
-            .to_string()
-            .into_bytes();
-
-        Self::view(client, &params.contract_id.to_string(), method_name, args).await
-    }
-
-    /// Default trait function to register the node.
-    async fn register_node(client: Arc<Self::Client>, params: Params<'_>) -> Result<Vec<u8>> {
-        let signed_tx = params
-            .one::<Vec<u8>>()
-            .map_err(|_| ChainAdapterError::BadParams("register_node".to_string()))?;
-
-        Self::send_tx(client, &signed_tx).await
-    }
-
-    /// Default trait function to remove the node.
-    async fn remove_node(client: Arc<Self::Client>, params: Params<'_>) -> Result<Vec<u8>> {
-        let signed_tx = params
-            .one::<Vec<u8>>()
-            .map_err(|_| ChainAdapterError::BadParams("register_node".to_string()))?;
-
-        Self::send_tx(client, &signed_tx).await
-    }
-
-    /// Default trait function to set the node socket address.
-    async fn set_node_socket_address(client: Arc<Self::Client>, params: Params<'_>) -> Result<Vec<u8>> {
-        let signed_tx = params
-            .one::<Vec<u8>>()
-            .map_err(|_| ChainAdapterError::BadParams("register_node".to_string()))?;
-
-        Self::send_tx(client, &signed_tx).await
-    }
+    async fn view(client: Self::Client, contract_id: &str, method_name: &str, args: Vec<u8>) -> Result<Vec<u8>>;
 }

--- a/node/src/host/runtime_host.rs
+++ b/node/src/host/runtime_host.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix::prelude::*;
 use seda_chains::{AnotherChain, ChainAdapterTrait, Client, NearChain};
 use seda_config::{ChainConfigs, NodeConfig};
@@ -21,8 +19,8 @@ impl HostAdapter for RuntimeAdapter {
 
     async fn new(config: ChainConfigs) -> Result<Self> {
         Ok(Self {
-            another_client: Client::Another(Arc::new(AnotherChain::new_client(&config.another)?)),
-            near_client:    Client::Near(Arc::new(NearChain::new_client(&config.near)?)),
+            another_client: Client::Another(AnotherChain::new_client(&config.another)?),
+            near_client:    Client::Near(NearChain::new_client(&config.near)?),
             chains_config:  config,
         })
     }

--- a/runtime/core/src/test_host.rs
+++ b/runtime/core/src/test_host.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use futures::lock::Mutex;
 use lazy_static::lazy_static;
@@ -26,8 +26,8 @@ impl HostAdapter for RuntimeTestAdapter {
 
     async fn new(config: ChainConfigs) -> Result<Self> {
         Ok(Self {
-            another_client: Client::Another(Arc::new(AnotherChain::new_client(&config.another)?)),
-            near_client:    Client::Near(Arc::new(NearChain::new_client(&config.near)?)),
+            another_client: Client::Another(AnotherChain::new_client(&config.another)?),
+            near_client:    Client::Near(NearChain::new_client(&config.near)?),
             chain_configs:  config,
         })
     }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To clean up the chain trait of unnecessary logic, they did not need.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Removes all but the `view`, `send_tx`, `sign_tx`, and `construct_signed_tx` methods.

Additionally, changes the `Client` associated type to be `Arc<...>` to clean up the use of `Arc::new` everywhere.
Finally, changes the `Client` enum and methods on that type to use the chains client type instead of manually specifying the exact type again.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Run existing tests.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
-->

N/A
