### PR TITLE
feat(runtime): Add p2p broadcasting & receiving support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,7 +4526,6 @@ name = "seda-p2p"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "futures",
  "libp2p",
  "seda-config",
  "seda-runtime-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4529,6 +4529,7 @@ dependencies = [
  "futures",
  "libp2p",
  "seda-config",
+ "seda-runtime-sdk",
  "thiserror",
  "tokio",
  "tracing",

--- a/node/src/app/mod.rs
+++ b/node/src/app/mod.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use actix::prelude::*;
-use futures::channel::mpsc::Sender;
 use parking_lot::RwLock;
 use seda_config::{ChainConfigs, NodeConfig};
 use seda_runtime::HostAdapter;
 use seda_runtime_sdk::{events::EventId, p2p::P2PCommand};
+use tokio::sync::mpsc::Sender;
 use tracing::info;
 
 use crate::{

--- a/node/src/app/p2p_message_handler.rs
+++ b/node/src/app/p2p_message_handler.rs
@@ -1,0 +1,36 @@
+use actix::Addr;
+use futures::{channel::mpsc::Receiver, StreamExt};
+use seda_runtime_sdk::{
+    events::{Event, EventData},
+    p2p::P2PMessage,
+};
+
+use super::App;
+use crate::{event_queue_handler::AddEventToQueue, host::RuntimeAdapter};
+
+pub struct P2PMessageHandler {
+    p2p_message_receiver: Receiver<P2PMessage>,
+    app_addr:             Addr<App<RuntimeAdapter>>,
+}
+
+impl P2PMessageHandler {
+    pub fn new(p2p_message_receiver: Receiver<P2PMessage>, app_addr: Addr<App<RuntimeAdapter>>) -> Self {
+        Self {
+            p2p_message_receiver,
+            app_addr,
+        }
+    }
+
+    pub async fn listen(&mut self) {
+        loop {
+            if let Some(message) = self.p2p_message_receiver.next().await {
+                self.app_addr.do_send(AddEventToQueue {
+                    event: Event {
+                        id:   "p2p-message".to_string(),
+                        data: EventData::P2PMessage(message),
+                    },
+                });
+            }
+        }
+    }
+}

--- a/node/src/app/p2p_message_handler.rs
+++ b/node/src/app/p2p_message_handler.rs
@@ -1,9 +1,9 @@
 use actix::Addr;
-use futures::{channel::mpsc::Receiver, StreamExt};
 use seda_runtime_sdk::{
     events::{Event, EventData},
     p2p::P2PMessage,
 };
+use tokio::sync::mpsc::Receiver;
 
 use super::App;
 use crate::{event_queue_handler::AddEventToQueue, host::RuntimeAdapter};
@@ -23,7 +23,7 @@ impl P2PMessageHandler {
 
     pub async fn listen(&mut self) {
         loop {
-            if let Some(message) = self.p2p_message_receiver.next().await {
+            if let Some(message) = self.p2p_message_receiver.recv().await {
                 self.app_addr.do_send(AddEventToQueue {
                     event: Event {
                         id:   "p2p-message".to_string(),

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -10,12 +10,12 @@ mod runtime_job;
 
 mod host;
 use actix::prelude::*;
-use futures::channel::mpsc;
 pub(crate) use host::*;
 pub use host::{ChainCall, ChainView};
 use seda_config::{ChainConfigs, NodeConfig};
 use seda_p2p::libp2p::P2PServer;
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
+use tokio::sync::mpsc::channel;
 use tracing::info;
 
 use crate::app::Shutdown;
@@ -30,8 +30,8 @@ pub fn run(seda_server_address: &str, config: NodeConfig, chain_configs: ChainCo
     let system = System::new();
     // Initialize actors inside system context
     system.block_on(async {
-        let (p2p_message_sender, p2p_message_receiver) = mpsc::channel::<P2PMessage>(0);
-        let (p2p_command_sender, p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+        let (p2p_message_sender, p2p_message_receiver) = channel::<P2PMessage>(100);
+        let (p2p_command_sender, p2p_command_receiver) = channel::<P2PCommand>(100);
 
         // TODO: add number of workers as config with default value
         let app = App::<RuntimeAdapter>::new(config.clone(), seda_server_address, chain_configs, p2p_command_sender)

--- a/node/src/runtime_job.rs
+++ b/node/src/runtime_job.rs
@@ -1,7 +1,6 @@
 use std::{fs, path::PathBuf, sync::Arc};
 
 use actix::{prelude::*, Handler, Message};
-use futures::channel::mpsc::Sender;
 use parking_lot::Mutex;
 use seda_config::{ChainConfigs, NodeConfig};
 use seda_runtime::{HostAdapter, InMemory, Result, RunnableRuntime, Runtime, VmConfig, VmResult};
@@ -9,6 +8,7 @@ use seda_runtime_sdk::{
     events::{Event, EventData},
     p2p::P2PCommand,
 };
+use tokio::sync::mpsc::Sender;
 use tracing::info;
 
 #[derive(MessageResponse)]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 # TODO: remove dep this after removing stdin
 async-std = { version = "1.12.0" }
-futures = { workspace = true }
+tokio = { workspace = true }
 libp2p = { workspace = true, features = [
 	"gossipsub",
 	"noise",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -18,6 +18,7 @@ libp2p = { workspace = true, features = [
 ] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+seda-runtime-sdk = { workspace = true }
 
 [dev-dependencies]
 seda-config = { workspace = true }

--- a/p2p/src/libp2p/libp2p_test.rs
+++ b/p2p/src/libp2p/libp2p_test.rs
@@ -1,14 +1,14 @@
-use futures::{channel::mpsc, StreamExt};
-use libp2p::swarm::SwarmEvent;
+use libp2p::{futures::StreamExt, swarm::SwarmEvent};
 use seda_config::NodeConfigInner;
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
+use tokio::sync::mpsc::channel;
 
 use super::P2PServer;
 
 #[tokio::test]
 async fn p2p_service_works() {
-    let (p2p_message_sender, _p2p_message_receiver) = mpsc::channel::<P2PMessage>(0);
-    let (_p2p_command_sender, p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_message_sender, _p2p_message_receiver) = channel::<P2PMessage>(100);
+    let (_p2p_command_sender, p2p_command_receiver) = channel::<P2PCommand>(100);
 
     // TODO p2p should have its own config section.
     let config = NodeConfigInner::test_config();

--- a/p2p/src/libp2p/libp2p_test.rs
+++ b/p2p/src/libp2p/libp2p_test.rs
@@ -1,16 +1,25 @@
-use futures::StreamExt;
+use futures::{channel::mpsc, StreamExt};
 use libp2p::swarm::SwarmEvent;
 use seda_config::NodeConfigInner;
+use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 
 use super::P2PServer;
 
 #[tokio::test]
 async fn p2p_service_works() {
+    let (p2p_message_sender, _p2p_message_receiver) = mpsc::channel::<P2PMessage>(0);
+    let (_p2p_command_sender, p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+
     // TODO p2p should have its own config section.
     let config = NodeConfigInner::test_config();
-    let mut p2p_service = P2PServer::start_from_config(&config.p2p_server_address, &config.p2p_known_peers)
-        .await
-        .expect("P2P swarm cannot be started");
+    let mut p2p_service = P2PServer::start_from_config(
+        &config.p2p_server_address,
+        &config.p2p_known_peers,
+        p2p_message_sender,
+        p2p_command_receiver,
+    )
+    .await
+    .expect("P2P swarm cannot be started");
 
     loop {
         match p2p_service.swarm.select_next_some().await {

--- a/p2p/src/libp2p/mod.rs
+++ b/p2p/src/libp2p/mod.rs
@@ -5,6 +5,10 @@ mod transport;
 mod libp2p_test;
 
 use async_std::io::{self, prelude::BufReadExt};
+use futures::{
+    channel::mpsc::{Receiver, Sender},
+    SinkExt,
+};
 use libp2p::{
     futures::{select, StreamExt},
     gossipsub::{GossipsubEvent, IdentTopic},
@@ -14,6 +18,7 @@ use libp2p::{
     Multiaddr,
     PeerId,
 };
+use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 
 use self::behaviour::SedaBehaviour;
 use crate::{
@@ -24,14 +29,21 @@ use crate::{
 pub const GOSSIP_TOPIC: &str = "testnet";
 
 pub struct P2PServer {
-    pub known_peers:    Vec<String>,
-    pub local_key:      identity::Keypair,
-    pub server_address: String,
-    pub swarm:          Swarm<SedaBehaviour>,
+    pub known_peers:              Vec<String>,
+    pub local_key:                identity::Keypair,
+    pub server_address:           String,
+    pub swarm:                    Swarm<SedaBehaviour>,
+    pub message_sender_channel:   Sender<P2PMessage>,
+    pub command_receiver_channel: Receiver<P2PCommand>,
 }
 
 impl P2PServer {
-    pub async fn start_from_config(server_address: &str, known_peers: &[String]) -> Result<Self> {
+    pub async fn start_from_config(
+        server_address: &str,
+        known_peers: &[String],
+        message_sender_channel: Sender<P2PMessage>,
+        command_receiver_channel: Receiver<P2PCommand>,
+    ) -> Result<Self> {
         // Generate Peer ID
         // TODO: Support peer id from config and storage
         let local_key = identity::Keypair::generate_ed25519();
@@ -45,11 +57,15 @@ impl P2PServer {
         let mut swarm = Swarm::with_threadpool_executor(transport, seda_behaviour, PeerId::from(local_key.public()));
         swarm.listen_on(server_address.parse()?)?;
 
+        // Create channels so we can listen for p2p messages
+
         Ok(Self {
             known_peers: known_peers.to_vec(),
             local_key,
             server_address: server_address.to_string(),
             swarm,
+            message_sender_channel,
+            command_receiver_channel,
         })
     }
 
@@ -77,6 +93,7 @@ impl P2PServer {
 
         loop {
             select! {
+
                 // TODO: Remove stdin feature
                 line = stdin.select_next_some() => {
                     if let Err(e) = self.swarm
@@ -103,13 +120,30 @@ impl P2PServer {
                         propagation_source: peer_id,
                         message_id: id,
                         message,
-                    })) => tracing::info!(
-                        "Got message: '{}' with id: {id} from peer: {peer_id}",
-                        String::from_utf8_lossy(&message.data),
-                    ),
+                    })) => {
+                        tracing::info!(
+                            "Got message: '{}' with id: {id} from peer: {peer_id}",
+                            String::from_utf8_lossy(&message.data),
+                        );
 
+                        let source: Option<String> = message.source.map(|peer| peer.to_string());
+
+                        if let Err(err) = self.message_sender_channel.send(P2PMessage { source, data: message.data }).await {
+                            tracing::error!("Couldn't send message through channel: {err}");
+                        }
+                    },
                     _ => {}
-                }
+                },
+                task = self.command_receiver_channel.select_next_some() => match task {
+                    P2PCommand::Broadcast(data) => {
+                        if let Err(e) = self.swarm.behaviour_mut().gossipsub.publish(topic.clone(), data) {
+                            tracing::error!("Publish error: {e:?}");
+                        }
+                    },
+                    P2PCommand::Unicast(_unicast) => {
+                        unimplemented!("Todo unicast");
+                    }
+                },
             }
         }
     }

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 wasmer = { workspace = true, features = [
 	"default-cranelift",
 	"default-universal",

--- a/runtime/core/src/errors.rs
+++ b/runtime/core/src/errors.rs
@@ -1,5 +1,6 @@
 use std::num::ParseIntError;
 
+use futures::channel::mpsc::SendError;
 use thiserror::Error;
 use wasmer::{CompileError, ExportError, InstantiationError};
 use wasmer_wasi::{FsError, WasiError, WasiStateCreationError};
@@ -52,6 +53,9 @@ pub enum RuntimeError {
     #[cfg(test)]
     #[error("Chain Adapter Error: {0}")]
     ChainAdapterError(#[from] seda_chains::ChainAdapterError),
+
+    #[error("P2P Command Channel Error: {0}")]
+    P2PCommandChannelError(#[from] SendError),
 }
 
 impl From<InstantiationError> for RuntimeError {

--- a/runtime/core/src/errors.rs
+++ b/runtime/core/src/errors.rs
@@ -1,7 +1,8 @@
 use std::num::ParseIntError;
 
-use futures::channel::mpsc::SendError;
+use seda_runtime_sdk::p2p::P2PCommand;
 use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
 use wasmer::{CompileError, ExportError, InstantiationError};
 use wasmer_wasi::{FsError, WasiError, WasiStateCreationError};
 #[derive(Debug, Error)]
@@ -55,7 +56,7 @@ pub enum RuntimeError {
     ChainAdapterError(#[from] seda_chains::ChainAdapterError),
 
     #[error("P2P Command Channel Error: {0}")]
-    P2PCommandChannelError(#[from] SendError),
+    P2PCommandChannelError(#[from] SendError<P2PCommand>),
 }
 
 impl From<InstantiationError> for RuntimeError {

--- a/runtime/core/src/runtime.rs
+++ b/runtime/core/src/runtime.rs
@@ -1,10 +1,10 @@
 use std::{io::Read, sync::Arc};
 
-use futures::{channel::mpsc::Sender, SinkExt};
 use parking_lot::Mutex;
 use seda_config::{ChainConfigs, NodeConfig};
 use seda_runtime_sdk::{p2p::P2PCommand, CallSelfAction, Promise, PromiseAction, PromiseStatus};
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::Sender;
 use tracing::info;
 use wasmer::{Instance, Module, Store};
 use wasmer_wasi::{Pipe, WasiState};
@@ -87,7 +87,7 @@ impl<HA: HostAdapter> RunnableRuntime for Runtime<HA> {
         promise_queue: PromiseQueue,
         output: &mut Vec<String>,
         promise_queue_trace: &mut Vec<PromiseQueue>,
-        mut p2p_command_sender_channel: Sender<P2PCommand>,
+        p2p_command_sender_channel: Sender<P2PCommand>,
     ) -> Result<u8> {
         let mut next_promise_queue = PromiseQueue::new();
         let mut promise_queue_mut = promise_queue.clone();
@@ -246,7 +246,7 @@ impl<HA: HostAdapter> RunnableRuntime for Runtime<HA> {
                     PromiseAction::P2PBroadcast(p2p_broadcast_action) => {
                         p2p_command_sender_channel
                             .send(P2PCommand::Broadcast(p2p_broadcast_action.data.clone()))
-                            .await?
+                            .await?;
                     }
                 }
             }

--- a/runtime/core/src/runtime_test.rs
+++ b/runtime/core/src/runtime_test.rs
@@ -1,10 +1,10 @@
 use std::{env, fs, path::PathBuf, sync::Arc};
 
-use futures::channel::mpsc;
 use parking_lot::Mutex;
 use seda_config::{ChainConfigsInner, NodeConfigInner};
 use seda_runtime_sdk::p2p::P2PCommand;
 use serde_json::json;
+use tokio::sync::mpsc;
 
 use crate::{test::RuntimeTestAdapter, HostAdapter, InMemory, MemoryAdapter, RunnableRuntime, Runtime, VmConfig};
 
@@ -27,7 +27,7 @@ fn memory_adapter() -> Arc<Mutex<InMemory>> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_promise_queue_multiple_calls_with_external_traits() {
     set_env_vars();
-    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(100);
     let wasm_binary = read_wasm_target("promise-wasm-bin");
     let node_config = NodeConfigInner::test_config();
     let memory_adapter = memory_adapter();
@@ -62,7 +62,7 @@ async fn test_bad_wasm_file() {
     set_env_vars();
 
     let node_config = NodeConfigInner::test_config();
-    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(100);
     let mut runtime = Runtime::<RuntimeTestAdapter>::new(node_config, ChainConfigsInner::test_config(), false)
         .await
         .unwrap();
@@ -77,7 +77,7 @@ async fn test_bad_wasm_file() {
                 start_func:   None,
                 debug:        true,
             },
-            memory_adapter,
+            memory_adapter(),
             p2p_command_sender,
         )
         .await;
@@ -90,7 +90,7 @@ async fn test_bad_wasm_file() {
 #[should_panic(expected = "non_existing_function")]
 async fn test_non_existing_function() {
     set_env_vars();
-    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(100);
     let wasm_binary = read_wasm_target("promise-wasm-bin");
     let node_config = NodeConfigInner::test_config();
     let memory_adapter = memory_adapter();
@@ -120,7 +120,7 @@ async fn test_non_existing_function() {
 async fn test_promise_queue_http_fetch() {
     set_env_vars();
     let fetch_url = "https://swapi.dev/api/planets/1/".to_string();
-    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(100);
 
     let wasm_binary = read_wasm_target("promise-wasm-bin");
     let node_config = NodeConfigInner::test_config();
@@ -161,7 +161,7 @@ async fn test_promise_queue_http_fetch() {
 async fn test_memory_adapter() {
     set_env_vars();
     let node_config = NodeConfigInner::test_config();
-    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(100);
     let memory_adapter = memory_adapter();
     let mut runtime = Runtime::<RuntimeTestAdapter>::new(node_config, ChainConfigsInner::test_config(), false)
         .await
@@ -205,7 +205,7 @@ async fn test_memory_adapter() {
 #[should_panic(expected = "not implemented")]
 async fn test_cli_demo_view_another_chain() {
     set_env_vars();
-    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(100);
     let wasm_binary = read_wasm_target("demo-cli");
     let node_config = NodeConfigInner::test_config();
     let memory_adapter = memory_adapter();
@@ -247,7 +247,7 @@ async fn test_cli_demo_view_another_chain() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_limited_runtime() {
     set_env_vars();
-    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(0);
+    let (p2p_command_sender, _p2p_command_receiver) = mpsc::channel::<P2PCommand>(100);
     let wasm_binary = read_wasm_target("promise-wasm-bin");
     let node_config = NodeConfigInner::test_config();
     let memory_adapter = memory_adapter();

--- a/runtime/sdk/src/events.rs
+++ b/runtime/sdk/src/events.rs
@@ -1,11 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+use crate::p2p::P2PMessage;
+
 pub type EventId = String;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EventData {
     // Tick types
     ChainTick,
+    P2PMessage(P2PMessage),
     CliCall(Vec<String>),
 }
 

--- a/runtime/sdk/src/lib.rs
+++ b/runtime/sdk/src/lib.rs
@@ -2,6 +2,7 @@ mod chain;
 pub use chain::Chain;
 mod level;
 pub use level::Level;
+pub mod p2p;
 mod promises;
 
 #[cfg(feature = "wasm")]
@@ -16,6 +17,7 @@ pub use promises::{
     DatabaseGetAction,
     DatabaseSetAction,
     HttpAction,
+    P2PBroadcastAction,
     Promise,
     PromiseAction,
     PromiseStatus,

--- a/runtime/sdk/src/p2p.rs
+++ b/runtime/sdk/src/p2p.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct P2PMessage {
+    pub source: Option<String>,
+    pub data:   Vec<u8>,
+}
+
+pub struct UnicastCommand {
+    pub peer_id: String,
+    pub data:    Vec<u8>,
+}
+
+pub enum P2PCommand {
+    Broadcast(Vec<u8>),
+    Unicast(UnicastCommand),
+}

--- a/runtime/sdk/src/p2p.rs
+++ b/runtime/sdk/src/p2p.rs
@@ -6,11 +6,13 @@ pub struct P2PMessage {
     pub data:   Vec<u8>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct UnicastCommand {
     pub peer_id: String,
     pub data:    Vec<u8>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum P2PCommand {
     Broadcast(Vec<u8>),
     Unicast(UnicastCommand),

--- a/runtime/sdk/src/promises/actions.rs
+++ b/runtime/sdk/src/promises/actions.rs
@@ -13,6 +13,7 @@ pub enum PromiseAction {
     ChainView(ChainViewAction),
     ChainCall(ChainCallAction),
     TriggerEvent(TriggerEventAction),
+    P2PBroadcast(P2PBroadcastAction),
 }
 
 impl PromiseAction {
@@ -32,6 +33,7 @@ impl fmt::Display for PromiseAction {
             Self::ChainView(_) => write!(f, "chain_view"),
             Self::ChainCall(_) => write!(f, "chain_call"),
             Self::TriggerEvent(_) => write!(f, "trigger_event"),
+            Self::P2PBroadcast(_) => write!(f, "p2p_broadcast"),
         }
     }
 }
@@ -79,4 +81,9 @@ pub struct ChainCallAction {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TriggerEventAction {
     pub event: Event,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct P2PBroadcastAction {
+    pub data: Vec<u8>,
 }

--- a/runtime/sdk/src/wasm/mod.rs
+++ b/runtime/sdk/src/wasm/mod.rs
@@ -8,6 +8,7 @@ mod execution;
 mod http;
 mod log;
 mod memory;
+mod p2p;
 mod promise;
 mod raw;
 
@@ -21,4 +22,5 @@ pub use execution::*;
 pub use http::*;
 pub use log::*;
 pub use memory::*;
+pub use p2p::*;
 pub use promise::*;

--- a/runtime/sdk/src/wasm/mod.rs
+++ b/runtime/sdk/src/wasm/mod.rs
@@ -22,5 +22,6 @@ pub use execution::*;
 pub use http::*;
 pub use log::*;
 pub use memory::*;
+#[cfg(feature = "full")]
 pub use p2p::*;
 pub use promise::*;

--- a/runtime/sdk/src/wasm/p2p.rs
+++ b/runtime/sdk/src/wasm/p2p.rs
@@ -1,0 +1,6 @@
+use super::Promise;
+use crate::{P2PBroadcastAction, PromiseAction};
+
+pub fn p2p_broadcast_message(data: Vec<u8>) -> Promise {
+    Promise::new(PromiseAction::P2PBroadcast(P2PBroadcastAction { data }))
+}

--- a/wasm/cli/src/main.rs
+++ b/wasm/cli/src/main.rs
@@ -1,7 +1,6 @@
 use clap::{Parser, Subcommand};
 use seda_runtime_sdk::{
-    events::{Event, EventData},
-    wasm::{call_self, chain_call, chain_view, db_set, http_fetch, log, trigger_event, Promise},
+    wasm::{call_self, chain_call, chain_view, db_set, http_fetch, log, p2p_broadcast_message, Promise},
     Chain,
     PromiseStatus,
 };
@@ -18,6 +17,9 @@ struct Options {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    P2p {
+        message: String,
+    },
     Hello,
     HttpFetch {
         url: String,
@@ -46,12 +48,11 @@ fn main() {
             Commands::HttpFetch { url } => {
                 http_fetch(&url).start().then(call_self("http_fetch_result", vec![]));
             }
+            Commands::P2p { message } => {
+                println!("Received a message from inside wasm {message}");
+                p2p_broadcast_message(vec![23]).start();
+            }
             Commands::Hello => {
-                trigger_event(Event {
-                    id:   "test".to_string(),
-                    data: EventData::ChainTick,
-                })
-                .start();
                 println!("Hello World from inside wasm");
             }
             Commands::View {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Add a way for the runtime to send and receive p2p messages from inside the WASM runtime. 

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

It introduces two channels a message & command channel. The message channel is for getting a p2p message and dispatching that to our runtime. the command channel is for the runtime to dispatch a broadcast/unicast message. the p2p server listens to this channel and acts accordingly. 

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Run two servers and type a message inside the terminal when they are connected. The p2p message will be given to the wasm runtime and will send a message back