### PR TITLE
feat(contracts): implement get current slot and epoch

### DIFF
--- a/contracts/src/epoch.rs
+++ b/contracts/src/epoch.rs
@@ -1,13 +1,13 @@
 use near_sdk::{env, near_bindgen};
 
-use crate::{slot::SECONDS_PER_SLOT, MainchainContract, MainchainContractExt};
+use crate::{slot::NEAR_BLOCKS_PER_SEDA_SLOT, MainchainContract, MainchainContractExt};
 
-const SLOTS_PER_EPOCH: u64 = 32;
+pub const SLOTS_PER_EPOCH: u64 = 32;
 
 /// Contract public methods
 #[near_bindgen]
 impl MainchainContract {
     pub fn get_current_epoch(&self) -> u64 {
-        env::block_timestamp() / (SECONDS_PER_SLOT * SLOTS_PER_EPOCH)
+        env::block_height() / (NEAR_BLOCKS_PER_SEDA_SLOT * SLOTS_PER_EPOCH)
     }
 }

--- a/contracts/src/epoch.rs
+++ b/contracts/src/epoch.rs
@@ -1,0 +1,13 @@
+use near_sdk::{env, near_bindgen};
+
+use crate::{slot::SECONDS_PER_SLOT, MainchainContract, MainchainContractExt};
+
+const SLOTS_PER_EPOCH: u64 = 32;
+
+/// Contract public methods
+#[near_bindgen]
+impl MainchainContract {
+    pub fn get_current_epoch(&self) -> u64 {
+        env::block_timestamp() / (SECONDS_PER_SLOT * SLOTS_PER_EPOCH)
+    }
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod block;
 pub mod data_request;
+pub mod epoch;
 pub mod merkle;
 pub mod node_registry;
+pub mod slot;
 pub mod storage;
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
@@ -64,4 +66,5 @@ mod tests {
     mod block_test;
     mod data_request_test;
     mod node_registry_test;
+    mod slot_test;
 }

--- a/contracts/src/slot.rs
+++ b/contracts/src/slot.rs
@@ -2,12 +2,12 @@ use near_sdk::{env, near_bindgen};
 
 use crate::{MainchainContract, MainchainContractExt};
 
-pub const SECONDS_PER_SLOT: u64 = 12;
+pub const NEAR_BLOCKS_PER_SEDA_SLOT: u64 = 10; // at 1.2s/block, 12s/slot
 
 /// Contract public methods
 #[near_bindgen]
 impl MainchainContract {
     pub fn get_current_slot(&self) -> u64 {
-        env::block_timestamp() / SECONDS_PER_SLOT
+        env::block_height() / NEAR_BLOCKS_PER_SEDA_SLOT
     }
 }

--- a/contracts/src/slot.rs
+++ b/contracts/src/slot.rs
@@ -1,0 +1,13 @@
+use near_sdk::{env, near_bindgen};
+
+use crate::{MainchainContract, MainchainContractExt};
+
+pub const SECONDS_PER_SLOT: u64 = 12;
+
+/// Contract public methods
+#[near_bindgen]
+impl MainchainContract {
+    pub fn get_current_slot(&self) -> u64 {
+        env::block_timestamp() / SECONDS_PER_SLOT
+    }
+}

--- a/contracts/src/slot_test.rs
+++ b/contracts/src/slot_test.rs
@@ -1,0 +1,44 @@
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use near_sdk::{test_utils::VMContextBuilder, testing_env, VMContext};
+
+    use crate::MainchainContract;
+
+    fn get_context(block_timestamp: u64) -> VMContext {
+        VMContextBuilder::new()
+            .block_timestamp(block_timestamp)
+            .is_view(true)
+            .build()
+    }
+
+    #[test]
+    fn get_current_slot() {
+        let contract = MainchainContract::new();
+
+        testing_env!(get_context(0)); // unix epoch
+        assert_eq!(contract.get_current_slot(), 0);
+
+        testing_env!(get_context(11)); // unix epoch + 11 seconds (same slot)
+        assert_eq!(contract.get_current_slot(), 0);
+
+        testing_env!(get_context(12)); //  // unix epoch + 12 seconds (new slot)
+        assert_eq!(contract.get_current_slot(), 1);
+    }
+
+    #[test]
+    fn get_current_epoch() {
+        let contract = MainchainContract::new();
+
+        testing_env!(get_context(0)); // unix epoch
+        assert_eq!(contract.get_current_epoch(), 0);
+
+        testing_env!(get_context(12)); // unix epoch + 12 seconds (new slot but same epoch)
+        assert_eq!(contract.get_current_epoch(), 0);
+        assert_eq!(contract.get_current_slot(), 1);
+
+        testing_env!(get_context(12 * 32)); // unix epoch + 12 seconds (new epoch)
+        assert_eq!(contract.get_current_epoch(), 1);
+        assert_eq!(contract.get_current_slot(), 32);
+    }
+}

--- a/contracts/src/slot_test.rs
+++ b/contracts/src/slot_test.rs
@@ -3,42 +3,39 @@
 mod tests {
     use near_sdk::{test_utils::VMContextBuilder, testing_env, VMContext};
 
-    use crate::MainchainContract;
+    use crate::{epoch::SLOTS_PER_EPOCH, slot::NEAR_BLOCKS_PER_SEDA_SLOT, MainchainContract};
 
-    fn get_context(block_timestamp: u64) -> VMContext {
-        VMContextBuilder::new()
-            .block_timestamp(block_timestamp)
-            .is_view(true)
-            .build()
+    fn get_context(block_index: u64) -> VMContext {
+        VMContextBuilder::new().block_index(block_index).is_view(true).build()
     }
 
     #[test]
     fn get_current_slot() {
         let contract = MainchainContract::new();
 
-        testing_env!(get_context(0)); // unix epoch
-        assert_eq!(contract.get_current_slot(), 0);
+        testing_env!(get_context(0)); // block 0
+        assert_eq!(contract.get_current_slot(), 0); // slot 0
 
-        testing_env!(get_context(11)); // unix epoch + 11 seconds (same slot)
-        assert_eq!(contract.get_current_slot(), 0);
+        testing_env!(get_context(NEAR_BLOCKS_PER_SEDA_SLOT - 1)); // block 9
+        assert_eq!(contract.get_current_slot(), 0); // slot 0
 
-        testing_env!(get_context(12)); //  // unix epoch + 12 seconds (new slot)
-        assert_eq!(contract.get_current_slot(), 1);
+        testing_env!(get_context(NEAR_BLOCKS_PER_SEDA_SLOT)); // block 10
+        assert_eq!(contract.get_current_slot(), 1); // slot 1
     }
 
     #[test]
     fn get_current_epoch() {
         let contract = MainchainContract::new();
 
-        testing_env!(get_context(0)); // unix epoch
-        assert_eq!(contract.get_current_epoch(), 0);
+        testing_env!(get_context(0)); // block 0
+        assert_eq!(contract.get_current_epoch(), 0); // epoch 0
 
-        testing_env!(get_context(12)); // unix epoch + 12 seconds (new slot but same epoch)
-        assert_eq!(contract.get_current_epoch(), 0);
-        assert_eq!(contract.get_current_slot(), 1);
+        testing_env!(get_context(NEAR_BLOCKS_PER_SEDA_SLOT * SLOTS_PER_EPOCH - 1)); // block 319
+        assert_eq!(contract.get_current_slot(), 31); // slot 31
+        assert_eq!(contract.get_current_epoch(), 0); // epoch 0
 
-        testing_env!(get_context(12 * 32)); // unix epoch + 12 seconds (new epoch)
-        assert_eq!(contract.get_current_epoch(), 1);
-        assert_eq!(contract.get_current_slot(), 32);
+        testing_env!(get_context(NEAR_BLOCKS_PER_SEDA_SLOT * SLOTS_PER_EPOCH)); // block 320
+        assert_eq!(contract.get_current_slot(), 32); // slot 32
+        assert_eq!(contract.get_current_epoch(), 1); // epoch 1
     }
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Similarly to Ethereum 2.0, SEDA protocol is based on the concepts of slots and epochs. This PR introduces two functions on the NEAR mainchain contract to calculate both.

## Explanation of Changes

Added two public-facing functions:
- `get_current_slot()`
- `get_current_epoch()`

Both function are non-state modifying, calculated based on the NEAR block's height. This borrows two constants from the Ethereum PoS spec:
- NEAR_BLOCKS_PER_SEDA_SLOT to 10 (which averages 12 seconds per slot with NEAR blocks every 1.2 seconds)
- SLOTS_PER_EPOCH to 32 slots

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

`slot_test.rs` includes tests for checking the slot and epoch while passing a mock block height. First it is set to block 0, then incremented to block 10 to check if the slot has increased (similar for epochs).

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
-->

n/a
