### PR TITLE
Add ability to remotely add/remove/list peers

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -18,6 +18,10 @@ This document contains the help content for the `seda` command-line program.
 * [`seda node update set-pending-owner`↴](#seda-node-update-set-pending-owner)
 * [`seda node update set-socket-address`↴](#seda-node-update-set-socket-address)
 * [`seda node unregister`↴](#seda-node-unregister)
+* [`seda node peers`↴](#seda-node-peers)
+* [`seda node peers add`↴](#seda-node-peers-add)
+* [`seda node peers list`↴](#seda-node-peers-list)
+* [`seda node peers remove`↴](#seda-node-peers-remove)
 * [`seda sub-chain`↴](#seda-sub-chain)
 * [`seda sub-chain call`↴](#seda-sub-chain-call)
 * [`seda sub-chain view`↴](#seda-sub-chain-view)
@@ -101,6 +105,7 @@ Commands to interact with the SEDA node
 * `register` — Register a node from the given deposit and socket address
 * `update` — Update a node by either accepting ownership, setting the pending owner, or changing the socket address
 * `unregister` — Unregister a node from the given node ID
+* `peers` — Commands for interacting with the p2p peers
 
 ###### **Options:**
 
@@ -257,6 +262,52 @@ Unregister a node from the given node ID
 
 
 
+## `seda node peers`
+
+Commands for interacting with the p2p peers
+
+**Usage:** `seda node peers <COMMAND>`
+
+###### **Subcommands:**
+
+* `add` — Adds a peer to a running node
+* `list` — Lists all currently connected peers
+* `remove` — Removes a connected peer
+
+
+
+## `seda node peers add`
+
+Adds a peer to a running node
+
+**Usage:** `seda node peers add <MULTI_ADDR>`
+
+###### **Arguments:**
+
+* `<MULTI_ADDR>` — A libp2p compatible address (ex. /ip4/127.0.0.1/tcp/44635)
+
+
+
+## `seda node peers list`
+
+Lists all currently connected peers
+
+**Usage:** `seda node peers list`
+
+
+
+## `seda node peers remove`
+
+Removes a connected peer
+
+**Usage:** `seda node peers remove <PEER_ID>`
+
+###### **Arguments:**
+
+* `<PEER_ID>` — A libp2p peer id (ex. 12D3KooWRg13CAzihqGpVfifoeK4nmZ15D3vpZSPfmaDT53CBr9R)
+
+
+
 ## `seda sub-chain`
 
 Debug commands to help interact with sub-chains
@@ -330,137 +381,3 @@ Views the specified method on the specified chain with the given args and contra
     This document was generated automatically by
     <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
- < S E C R E T _ K E Y > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   s e c r e t   k e y   c o n f i g   v a l u e 
- *   ` - - s i g n e r - a c c o u n t - i d   < S I G N E R _ A C C O U N T _ I D > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   s i g n e r   a c c o u n t   I D   c o n f i g   v a l u e 
- *   ` - - c o n t r a c t - a c c o u n t - i d   < C O N T R A C T _ A C C O U N T _ I D > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   c o n t r a c t   a c c o u n t   I D   c o n f i g   v a l u e 
- *   ` - - p u b l i c - k e y   < P U B L I C _ K E Y > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p u b l i c   k e y   c o n f i g   v a l u e 
- *   ` - - j o b - m a n a g e r - i n t e r v a l - m s   < J O B _ M A N A G E R _ I N T E R V A L _ M S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   j o b   m a n a g e r   i n t e r v a l ( m s )   c o n f i g   v a l u e 
- *   ` - - r u n t i m e - w o r k e r - t h r e a d s   < R U N T I M E _ W O R K E R _ T H R E A D S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   r u n t i m e   w o r k e r   t h r e a d s   c o n f i g   v a l u e 
- *   ` - - p 2 p - s e r v e r - a d d r e s s   < P 2 P _ S E R V E R _ A D D R E S S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p 2 p   s e r v e r   a d d r e s s   c o n f i g   v a l u e 
- *   ` - - p 2 p - k n o w n - p e e r s   < P 2 P _ K N O W N _ P E E R S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p 2 p   k n o w n   p e e r s   c o n f i g   v a l u e 
- 
- 
- 
- # #   ` s e d a   n o d e   u p d a t e   a c c e p t - o w n e r s h i p ` 
- 
- * * U s a g e : * *   ` s e d a   n o d e   u p d a t e   a c c e p t - o w n e r s h i p ` 
- 
- 
- 
- # #   ` s e d a   n o d e   u p d a t e   s e t - p e n d i n g - o w n e r ` 
- 
- * * U s a g e : * *   ` s e d a   n o d e   u p d a t e   s e t - p e n d i n g - o w n e r   < O W N E R > ` 
- 
- # # # # # #   * * A r g u m e n t s : * * 
- 
- *   ` < O W N E R > ` 
- 
- 
- 
- # #   ` s e d a   n o d e   u p d a t e   s e t - s o c k e t - a d d r e s s ` 
- 
- * * U s a g e : * *   ` s e d a   n o d e   u p d a t e   s e t - s o c k e t - a d d r e s s   < A D D R E S S > ` 
- 
- # # # # # #   * * A r g u m e n t s : * * 
- 
- *   ` < A D D R E S S > ` 
- 
- 
- 
- # #   ` s e d a   n o d e   u n r e g i s t e r ` 
- 
- U n r e g i s t e r   a   n o d e   f r o m   t h e   g i v e n   n o d e   I D 
- 
- * * U s a g e : * *   ` s e d a   n o d e   u n r e g i s t e r   [ O P T I O N S ]   - - n o d e - i d   < N O D E _ I D > ` 
- 
- # # # # # #   * * O p t i o n s : * * 
- 
- *   ` - n ` ,   ` - - n o d e - i d   < N O D E _ I D > ` 
- *   ` - d ` ,   ` - - d e p o s i t   < D E P O S I T > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   d e p o s i t   c o n f i g   v a l u e 
- *   ` - g ` ,   ` - - g a s   < G A S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   g a s   c o n f i g   v a l u e 
- *   ` - - s e c r e t - k e y   < S E C R E T _ K E Y > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   s e c r e t   k e y   c o n f i g   v a l u e 
- *   ` - - s i g n e r - a c c o u n t - i d   < S I G N E R _ A C C O U N T _ I D > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   s i g n e r   a c c o u n t   I D   c o n f i g   v a l u e 
- *   ` - - c o n t r a c t - a c c o u n t - i d   < C O N T R A C T _ A C C O U N T _ I D > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   c o n t r a c t   a c c o u n t   I D   c o n f i g   v a l u e 
- *   ` - - p u b l i c - k e y   < P U B L I C _ K E Y > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p u b l i c   k e y   c o n f i g   v a l u e 
- *   ` - - j o b - m a n a g e r - i n t e r v a l - m s   < J O B _ M A N A G E R _ I N T E R V A L _ M S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   j o b   m a n a g e r   i n t e r v a l ( m s )   c o n f i g   v a l u e 
- *   ` - - r u n t i m e - w o r k e r - t h r e a d s   < R U N T I M E _ W O R K E R _ T H R E A D S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   r u n t i m e   w o r k e r   t h r e a d s   c o n f i g   v a l u e 
- *   ` - - p 2 p - s e r v e r - a d d r e s s   < P 2 P _ S E R V E R _ A D D R E S S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p 2 p   s e r v e r   a d d r e s s   c o n f i g   v a l u e 
- *   ` - - p 2 p - k n o w n - p e e r s   < P 2 P _ K N O W N _ P E E R S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p 2 p   k n o w n   p e e r s   c o n f i g   v a l u e 
- 
- 
- 
- # #   ` s e d a   s u b - c h a i n ` 
- 
- D e b u g   c o m m a n d s   t o   h e l p   i n t e r a c t   w i t h   s u b - c h a i n s 
- 
- * * U s a g e : * *   ` s e d a   s u b - c h a i n   [ O P T I O N S ]   < C O M M A N D > ` 
- 
- # # # # # #   * * S u b c o m m a n d s : * * 
- 
- *   ` c a l l `      C a l l s   t h e   s p e c i f i e d   m e t h o d   o n   t h e   s p e c i f i e d   c h a i n   w i t h   t h e   g i v e n   a r g s   a n d   c o n t r a c t   I D 
- *   ` v i e w `      V i e w s   t h e   s p e c i f i e d   m e t h o d   o n   t h e   s p e c i f i e d   c h a i n   w i t h   t h e   g i v e n   a r g s   a n d   c o n t r a c t   I D 
- 
- # # # # # #   * * O p t i o n s : * * 
- 
- *   ` - - c h a i n - r p c - u r l   < C H A I N _ R P C _ U R L > `      A n   o p t i o n   t o   o v e r r i d e   t h e   N e a r   c h a i n   r p c   u r l   c o n f i g   v a l u e 
- 
- 
- 
- # #   ` s e d a   s u b - c h a i n   c a l l ` 
- 
- C a l l s   t h e   s p e c i f i e d   m e t h o d   o n   t h e   s p e c i f i e d   c h a i n   w i t h   t h e   g i v e n   a r g s   a n d   c o n t r a c t   I D 
- 
- * * U s a g e : * *   ` s e d a   s u b - c h a i n   c a l l   [ O P T I O N S ]   < C H A I N >   < C O N T R A C T _ I D >   < M E T H O D _ N A M E >   < A R G S >   < C A L L _ D E P O S I T > ` 
- 
- # # # # # #   * * A r g u m e n t s : * * 
- 
- *   ` < C H A I N > `      T h e   s u b - c h a i n   t o   c a l l 
- 
-     P o s s i b l e   v a l u e s :   ` a n o t h e r ` ,   ` n e a r ` 
- 
- *   ` < C O N T R A C T _ I D > `      T h e   c o n t r a c t   I D   f o r   t h e   s u b - c h a i n 
- *   ` < M E T H O D _ N A M E > `      T h e   m e t h o d   n a m e   t o   c a l l 
- *   ` < A R G S > `      T h e   a r g s   t o   p a s s   t o   t h e   c a l l   m e t h o d 
- *   ` < C A L L _ D E P O S I T > `      T h e   d e p o s i t   f o r   t h e   c a l l   m e t h o d 
- 
- # # # # # #   * * O p t i o n s : * * 
- 
- *   ` - d ` ,   ` - - d e p o s i t   < D E P O S I T > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   d e p o s i t   c o n f i g   v a l u e 
- *   ` - g ` ,   ` - - g a s   < G A S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   g a s   c o n f i g   v a l u e 
- *   ` - - s e c r e t - k e y   < S E C R E T _ K E Y > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   s e c r e t   k e y   c o n f i g   v a l u e 
- *   ` - - s i g n e r - a c c o u n t - i d   < S I G N E R _ A C C O U N T _ I D > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   s i g n e r   a c c o u n t   I D   c o n f i g   v a l u e 
- *   ` - - c o n t r a c t - a c c o u n t - i d   < C O N T R A C T _ A C C O U N T _ I D > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   c o n t r a c t   a c c o u n t   I D   c o n f i g   v a l u e 
- *   ` - - p u b l i c - k e y   < P U B L I C _ K E Y > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p u b l i c   k e y   c o n f i g   v a l u e 
- *   ` - - j o b - m a n a g e r - i n t e r v a l - m s   < J O B _ M A N A G E R _ I N T E R V A L _ M S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   j o b   m a n a g e r   i n t e r v a l ( m s )   c o n f i g   v a l u e 
- *   ` - - r u n t i m e - w o r k e r - t h r e a d s   < R U N T I M E _ W O R K E R _ T H R E A D S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   r u n t i m e   w o r k e r   t h r e a d s   c o n f i g   v a l u e 
- *   ` - - p 2 p - s e r v e r - a d d r e s s   < P 2 P _ S E R V E R _ A D D R E S S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p 2 p   s e r v e r   a d d r e s s   c o n f i g   v a l u e 
- *   ` - - p 2 p - k n o w n - p e e r s   < P 2 P _ K N O W N _ P E E R S > `      A n   o p t i o n   t o   o v e r r i d e   t h e   n o d e   p 2 p   k n o w n   p e e r s   c o n f i g   v a l u e 
- 
- 
- 
- # #   ` s e d a   s u b - c h a i n   v i e w ` 
- 
- V i e w s   t h e   s p e c i f i e d   m e t h o d   o n   t h e   s p e c i f i e d   c h a i n   w i t h   t h e   g i v e n   a r g s   a n d   c o n t r a c t   I D 
- 
- * * U s a g e : * *   ` s e d a   s u b - c h a i n   v i e w   < C H A I N >   < C O N T R A C T _ I D >   < M E T H O D _ N A M E >   < A R G S > ` 
- 
- # # # # # #   * * A r g u m e n t s : * * 
- 
- *   ` < C H A I N > `      T h e   s u b - c h a i n   t o   c a l l 
- 
-     P o s s i b l e   v a l u e s :   ` a n o t h e r ` ,   ` n e a r ` 
- 
- *   ` < C O N T R A C T _ I D > `      T h e   c o n t r a c t   I D   f o r   t h e   s u b - c h a i n 
- *   ` < M E T H O D _ N A M E > `      T h e   m e t h o d   n a m e   t o   v i e w 
- *   ` < A R G S > `      T h e   a r g s   t o   p a s s   t o   t h e   v i e w   m e t h o d 
- 
- 
- 
- < h r / > 
- 
- < s m a l l > < i > 
-         T h i s   d o c u m e n t   w a s   g e n e r a t e d   a u t o m a t i c a l l y   b y 
-         < a   h r e f = " h t t p s : / / c r a t e s . i o / c r a t e s / c l a p - m a r k d o w n " > < c o d e > c l a p - m a r k d o w n < / c o d e > < / a > . 
- < / i > < / s m a l l > 
- 
- 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,8 +4539,10 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "libp2p",
+ "parking_lot 0.12.1",
  "seda-config",
  "seda-runtime-sdk",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",

--- a/cli/src/cli/commands/node/mod.rs
+++ b/cli/src/cli/commands/node/mod.rs
@@ -1,10 +1,12 @@
 use clap::Subcommand;
 use seda_config::{AppConfig, PartialChainConfigs};
 
+use self::peers::Peers;
 use crate::Result;
 
 mod bridge;
 mod get;
+mod peers;
 mod register;
 mod unregister;
 mod update;
@@ -34,6 +36,11 @@ pub enum Node {
     // seda node unregister -n 19
     /// Unregister a node from the given node ID.
     Unregister(unregister::Unregister),
+    /// Commands for interacting with the p2p peers
+    Peers {
+        #[command(subcommand)]
+        sub_peers_command: Peers,
+    },
 }
 
 impl Node {
@@ -46,6 +53,7 @@ impl Node {
             Self::Register(register_node) => register_node.handle(config, chains_config).await,
             Self::Update(update_node) => update_node.handle(config, chains_config).await,
             Self::Unregister(unregister_node) => unregister_node.handle(config, chains_config).await,
+            Self::Peers { sub_peers_command } => sub_peers_command.handle(config).await,
         }
     }
 }

--- a/cli/src/cli/commands/node/peers/add.rs
+++ b/cli/src/cli/commands/node/peers/add.rs
@@ -1,0 +1,23 @@
+use clap::Args;
+use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClientBuilder};
+use seda_config::AppConfig;
+
+use crate::Result;
+
+#[derive(Debug, Args)]
+pub struct AddPeer {
+    pub multi_addr: String,
+}
+
+impl AddPeer {
+    pub async fn handle(self, config: AppConfig) -> Result<()> {
+        let client = WsClientBuilder::default()
+            .build(format!("ws://{}", &config.seda_server_url))
+            .await?;
+
+        client.request("add_peer", rpc_params!(&self.multi_addr)).await?;
+        println!("Peer {} has been added", &self.multi_addr);
+
+        Ok(())
+    }
+}

--- a/cli/src/cli/commands/node/peers/list.rs
+++ b/cli/src/cli/commands/node/peers/list.rs
@@ -1,0 +1,20 @@
+use clap::Args;
+use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClientBuilder};
+use seda_config::AppConfig;
+
+use crate::Result;
+
+#[derive(Debug, Args)]
+pub struct ListPeers;
+
+impl ListPeers {
+    pub async fn handle(self, config: AppConfig) -> Result<()> {
+        let client = WsClientBuilder::default()
+            .build(format!("ws://{}", &config.seda_server_url))
+            .await?;
+
+        client.request("list_peers", rpc_params!()).await?;
+
+        Ok(())
+    }
+}

--- a/cli/src/cli/commands/node/peers/list.rs
+++ b/cli/src/cli/commands/node/peers/list.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClientBuilder};
 use seda_config::AppConfig;
+use serde_json::Value;
 
 use crate::Result;
 
@@ -13,7 +14,9 @@ impl ListPeers {
             .build(format!("ws://{}", &config.seda_server_url))
             .await?;
 
-        client.request("list_peers", rpc_params!()).await?;
+        let response: Value = client.request("list_peers", rpc_params!()).await?;
+
+        serde_json::to_writer_pretty(std::io::stdout(), &response)?;
 
         Ok(())
     }

--- a/cli/src/cli/commands/node/peers/mod.rs
+++ b/cli/src/cli/commands/node/peers/mod.rs
@@ -1,0 +1,23 @@
+use clap::Subcommand;
+use seda_config::AppConfig;
+
+use crate::Result;
+
+mod add;
+mod list;
+
+#[derive(Debug, Subcommand)]
+pub enum Peers {
+    /// Adds a peer to a running node
+    Add(add::AddPeer),
+    List(list::ListPeers),
+}
+
+impl Peers {
+    pub async fn handle(self, config: AppConfig) -> Result<()> {
+        match self {
+            Self::Add(add_peer) => add_peer.handle(config).await,
+            Self::List(list_peers) => list_peers.handle(config).await,
+        }
+    }
+}

--- a/cli/src/cli/commands/node/peers/mod.rs
+++ b/cli/src/cli/commands/node/peers/mod.rs
@@ -5,12 +5,16 @@ use crate::Result;
 
 mod add;
 mod list;
+mod remove;
 
 #[derive(Debug, Subcommand)]
 pub enum Peers {
     /// Adds a peer to a running node
     Add(add::AddPeer),
+    /// Lists all currently connected peers
     List(list::ListPeers),
+    /// Removes a connected peer
+    Remove(remove::RemovePeer),
 }
 
 impl Peers {
@@ -18,6 +22,7 @@ impl Peers {
         match self {
             Self::Add(add_peer) => add_peer.handle(config).await,
             Self::List(list_peers) => list_peers.handle(config).await,
+            Self::Remove(remove_peer) => remove_peer.handle(config).await,
         }
     }
 }

--- a/cli/src/cli/commands/node/peers/remove.rs
+++ b/cli/src/cli/commands/node/peers/remove.rs
@@ -5,19 +5,20 @@ use seda_config::AppConfig;
 use crate::Result;
 
 #[derive(Debug, Args)]
-pub struct AddPeer {
-    /// A libp2p compatible address (ex. /ip4/127.0.0.1/tcp/44635)
-    pub multi_addr: String,
+pub struct RemovePeer {
+    /// A libp2p peer id (ex.
+    /// 12D3KooWRg13CAzihqGpVfifoeK4nmZ15D3vpZSPfmaDT53CBr9R)
+    pub peer_id: String,
 }
 
-impl AddPeer {
+impl RemovePeer {
     pub async fn handle(self, config: AppConfig) -> Result<()> {
         let client = WsClientBuilder::default()
             .build(format!("ws://{}", &config.seda_server_url))
             .await?;
 
-        client.request("add_peer", rpc_params!(&self.multi_addr)).await?;
-        println!("Peer {} has been added", &self.multi_addr);
+        client.request("remove_peer", rpc_params!(&self.peer_id)).await?;
+        println!("Peer {} has been removed", &self.peer_id);
 
         Ok(())
     }

--- a/node/src/app/mod.rs
+++ b/node/src/app/mod.rs
@@ -3,11 +3,9 @@ use std::sync::Arc;
 use actix::prelude::*;
 use parking_lot::RwLock;
 use seda_config::{ChainConfigs, NodeConfig};
+use seda_p2p::PeerList;
 use seda_runtime::HostAdapter;
-use seda_runtime_sdk::{
-    events::EventId,
-    p2p::{self, P2PCommand},
-};
+use seda_runtime_sdk::{events::EventId, p2p::P2PCommand};
 use tokio::sync::mpsc::Sender;
 use tracing::info;
 
@@ -36,6 +34,7 @@ impl<HA: HostAdapter> App<HA> {
         rpc_server_address: &str,
         chain_configs: ChainConfigs,
         p2p_command_sender_channel: Sender<P2PCommand>,
+        known_peers: Arc<RwLock<PeerList>>,
     ) -> Self {
         // Have to clone beforehand in order for the variable to be moved. (We also need
         // the same sender for the RPC)
@@ -52,6 +51,7 @@ impl<HA: HostAdapter> App<HA> {
             runtime_worker.clone(),
             rpc_server_address,
             p2p_command_sender_channel.clone(),
+            known_peers.clone(),
         )
         .await
         .expect("Error starting jsonrpsee server");

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,5 +1,7 @@
 mod app;
 
+use std::sync::Arc;
+
 use app::{p2p_message_handler::P2PMessageHandler, App};
 mod errors;
 pub use errors::*;
@@ -12,8 +14,9 @@ mod host;
 use actix::prelude::*;
 pub(crate) use host::*;
 pub use host::{ChainCall, ChainView};
+use parking_lot::RwLock;
 use seda_config::{ChainConfigs, NodeConfig};
-use seda_p2p::libp2p::P2PServer;
+use seda_p2p::{libp2p::P2PServer, PeerList};
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 use tokio::sync::mpsc::channel;
 use tracing::info;
@@ -33,15 +36,23 @@ pub fn run(seda_server_address: &str, config: NodeConfig, chain_configs: ChainCo
         let (p2p_message_sender, p2p_message_receiver) = channel::<P2PMessage>(100);
         let (p2p_command_sender, p2p_command_receiver) = channel::<P2PCommand>(100);
 
+        let known_peers = Arc::new(RwLock::new(PeerList::from_vec(&config.p2p_known_peers)));
+
         // TODO: add number of workers as config with default value
-        let app = App::<RuntimeAdapter>::new(config.clone(), seda_server_address, chain_configs, p2p_command_sender)
-            .await
-            .start();
+        let app = App::<RuntimeAdapter>::new(
+            config.clone(),
+            seda_server_address,
+            chain_configs,
+            p2p_command_sender,
+            known_peers.clone(),
+        )
+        .await
+        .start();
 
         // TODO: Use config for P2P Server
         let mut p2p_server = P2PServer::start_from_config(
             &config.p2p_server_address,
-            &config.p2p_known_peers,
+            known_peers,
             p2p_message_sender,
             p2p_command_receiver,
         )

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -1,11 +1,18 @@
+use std::str::FromStr;
+
 use actix::prelude::*;
 use jsonrpsee::{
     core::{async_trait, Error},
     proc_macros::rpc,
     server::{ServerBuilder, ServerHandle},
 };
+use seda_p2p::libp2p::Multiaddr;
 use seda_runtime::HostAdapter;
-use seda_runtime_sdk::events::{Event, EventData};
+use seda_runtime_sdk::{
+    events::{Event, EventData},
+    p2p::{AddPeerCommand, P2PCommand},
+};
+use tokio::sync::mpsc::Sender;
 use tracing::debug;
 
 use crate::runtime_job::{RuntimeJob, RuntimeWorker};
@@ -14,10 +21,17 @@ use crate::runtime_job::{RuntimeJob, RuntimeWorker};
 pub trait Rpc {
     #[method(name = "cli")]
     async fn cli(&self, args: Vec<String>) -> Result<Vec<String>, Error>;
+
+    #[method(name = "add_peer")]
+    async fn add_peer(&self, multi_addr: String) -> Result<(), Error>;
+
+    #[method(name = "list_peers")]
+    async fn list_peers(&self) -> Result<(), Error>;
 }
 
 pub struct CliServer<HA: HostAdapter> {
-    runtime_worker: Addr<RuntimeWorker<HA>>,
+    runtime_worker:             Addr<RuntimeWorker<HA>>,
+    p2p_command_sender_channel: Sender<P2PCommand>,
 }
 
 #[async_trait]
@@ -38,15 +52,40 @@ impl<HA: HostAdapter> RpcServer for CliServer<HA> {
 
         Ok(result.map_err(|err| Error::Custom(err.to_string()))?.vm_result.output)
     }
+
+    async fn add_peer(&self, multi_addr: String) -> Result<(), Error> {
+        // To check before hand if the input is valid
+        if let Err(err) = Multiaddr::from_str(&multi_addr) {
+            return Err(Error::Custom(err.to_string()));
+        }
+
+        self.p2p_command_sender_channel
+            .send(P2PCommand::AddPeer(AddPeerCommand { multi_addr }))
+            .await
+            .map_err(|err| Error::Custom(err.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn list_peers(&self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 pub struct JsonRpcServer {
     handle: ServerHandle,
 }
 
 impl JsonRpcServer {
-    pub async fn start<HA: HostAdapter>(runtime_worker: Addr<RuntimeWorker<HA>>, addrs: &str) -> Result<Self, Error> {
+    pub async fn start<HA: HostAdapter>(
+        runtime_worker: Addr<RuntimeWorker<HA>>,
+        addrs: &str,
+        p2p_command_sender_channel: Sender<P2PCommand>,
+    ) -> Result<Self, Error> {
         let server = ServerBuilder::default().build(addrs).await?;
-        let rpc = CliServer { runtime_worker };
+        let rpc = CliServer {
+            runtime_worker,
+            p2p_command_sender_channel,
+        };
         let handle = server.start(rpc.into_rpc())?;
 
         Ok(Self { handle })

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -17,9 +17,11 @@ libp2p = { workspace = true, features = [
 	"macros",
 	"async-std"
 ] }
+parking_lot = { workspace = true }
+seda-runtime-sdk = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-seda-runtime-sdk = { workspace = true }
 
 [dev-dependencies]
 seda-config = { workspace = true }

--- a/p2p/src/errors.rs
+++ b/p2p/src/errors.rs
@@ -12,6 +12,8 @@ pub enum P2PAdapterError {
     Io(#[from] std::io::Error),
     #[error("libp2p multi addr error: {0}")]
     MultiAddr(#[from] libp2p::multiaddr::Error),
+    #[error("libp2p dial error: {0}")]
+    DialError(#[from] libp2p::swarm::DialError),
 }
 
 pub type Result<T, E = P2PAdapterError> = core::result::Result<T, E>;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -2,3 +2,5 @@ mod errors;
 pub use errors::*;
 
 pub mod libp2p;
+
+pub use crate::libp2p::peer_list::PeerList;

--- a/p2p/src/libp2p/libp2p_test.rs
+++ b/p2p/src/libp2p/libp2p_test.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+
 use libp2p::{futures::StreamExt, swarm::SwarmEvent};
+use parking_lot::RwLock;
 use seda_config::NodeConfigInner;
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 use tokio::sync::mpsc::channel;
 
 use super::P2PServer;
+use crate::libp2p::peer_list::PeerList;
 
 #[tokio::test]
 async fn p2p_service_works() {
@@ -12,9 +16,10 @@ async fn p2p_service_works() {
 
     // TODO p2p should have its own config section.
     let config = NodeConfigInner::test_config();
+    let known_peers = Arc::new(RwLock::new(PeerList::from_vec(&config.p2p_known_peers)));
     let mut p2p_service = P2PServer::start_from_config(
         &config.p2p_server_address,
-        &config.p2p_known_peers,
+        known_peers,
         p2p_message_sender,
         p2p_command_receiver,
     )

--- a/p2p/src/libp2p/peer_list.rs
+++ b/p2p/src/libp2p/peer_list.rs
@@ -1,0 +1,71 @@
+use std::{collections::HashMap, str::FromStr};
+
+use libp2p::{Multiaddr, PeerId};
+use serde_json::Value;
+
+pub struct PeerList {
+    addr_to_peer: HashMap<Multiaddr, Option<PeerId>>,
+    peer_to_addr: HashMap<PeerId, Multiaddr>,
+}
+
+impl PeerList {
+    pub fn from_vec(unparsed_multi_addresses: &[String]) -> PeerList {
+        let mut addr_to_peer = HashMap::new();
+
+        unparsed_multi_addresses.iter().for_each(|unparsed_addr| {
+            addr_to_peer.insert(Multiaddr::from_str(unparsed_addr).unwrap(), None);
+        });
+
+        PeerList {
+            addr_to_peer,
+            peer_to_addr: HashMap::new(),
+        }
+    }
+
+    pub fn add_peer(&mut self, multi_addr: Multiaddr, peer_id: Option<PeerId>) {
+        self.addr_to_peer.insert(multi_addr.clone(), peer_id);
+
+        if let Some(peer) = peer_id {
+            self.peer_to_addr.insert(peer, multi_addr);
+        }
+    }
+
+    pub fn set_peer_id(&mut self, multi_addr: Multiaddr, peer_id: PeerId) {
+        self.addr_to_peer.insert(multi_addr.clone(), Some(peer_id));
+        self.peer_to_addr.insert(peer_id, multi_addr);
+    }
+
+    pub fn remove_peer_by_addr(&mut self, multi_addr: Multiaddr) {
+        let item = self.addr_to_peer.get(&multi_addr);
+
+        if let Some(peer) = item {
+            if let Some(peer_id) = peer {
+                self.peer_to_addr.remove(peer_id);
+            }
+        }
+
+        self.addr_to_peer.remove(&multi_addr);
+    }
+
+    pub fn remove_peer_by_id(&mut self, peer_id: PeerId) {
+        let addr = self.peer_to_addr.get(&peer_id);
+
+        if let Some(multi_addr) = addr {
+            self.addr_to_peer.remove(multi_addr);
+        }
+    }
+
+    pub fn get_json(&self) -> Value {
+        let mut result: HashMap<String, Option<String>> = HashMap::new();
+
+        self.addr_to_peer.iter().for_each(|(addr, peer)| {
+            result.insert(addr.to_string(), peer.map(|p| p.to_base58()));
+        });
+
+        serde_json::json!(result)
+    }
+
+    pub fn get_all(&self) -> HashMap<Multiaddr, Option<PeerId>> {
+        self.addr_to_peer.clone()
+    }
+}

--- a/p2p/src/libp2p/peer_list.rs
+++ b/p2p/src/libp2p/peer_list.rs
@@ -38,10 +38,8 @@ impl PeerList {
     pub fn remove_peer_by_addr(&mut self, multi_addr: Multiaddr) {
         let item = self.addr_to_peer.get(&multi_addr);
 
-        if let Some(peer) = item {
-            if let Some(peer_id) = peer {
-                self.peer_to_addr.remove(peer_id);
-            }
+        if let Some(Some(peer_id)) = item {
+            self.peer_to_addr.remove(peer_id);
         }
 
         self.addr_to_peer.remove(&multi_addr);
@@ -53,19 +51,21 @@ impl PeerList {
         if let Some(multi_addr) = addr {
             self.addr_to_peer.remove(multi_addr);
         }
+
+        self.peer_to_addr.remove(&peer_id);
     }
 
     pub fn get_json(&self) -> Value {
-        let mut result: HashMap<String, Option<String>> = HashMap::new();
+        let mut result: HashMap<String, String> = HashMap::new();
 
-        self.addr_to_peer.iter().for_each(|(addr, peer)| {
-            result.insert(addr.to_string(), peer.map(|p| p.to_base58()));
+        self.peer_to_addr.iter().for_each(|(peer, addr)| {
+            result.insert(addr.to_string(), peer.to_base58());
         });
 
         serde_json::json!(result)
     }
 
-    pub fn get_all(&self) -> HashMap<Multiaddr, Option<PeerId>> {
-        self.addr_to_peer.clone()
+    pub fn get_all(&self) -> HashMap<PeerId, Multiaddr> {
+        self.peer_to_addr.clone()
     }
 }

--- a/runtime/sdk/src/p2p.rs
+++ b/runtime/sdk/src/p2p.rs
@@ -13,7 +13,19 @@ pub struct UnicastCommand {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AddPeerCommand {
+    pub multi_addr: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct RemovePeerCommand {
+    pub multi_addr: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum P2PCommand {
     Broadcast(Vec<u8>),
     Unicast(UnicastCommand),
+    AddPeer(AddPeerCommand),
+    RemovePeer(RemovePeerCommand),
 }

--- a/runtime/sdk/src/p2p.rs
+++ b/runtime/sdk/src/p2p.rs
@@ -19,7 +19,7 @@ pub struct AddPeerCommand {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RemovePeerCommand {
-    pub multi_addr: String,
+    pub peer_id: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

A node operator should be able to add/remove/list peers on the fly through the CLI. This implements those functions

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Move known_peers up a level so we can pass it to the RPC and P2PServer through Arc<RwLock<_>>. Also added the commands in the cli package and implement the P2PCommand (mpsc channel)

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

1. Start two nodes
2. Use `seda node peers list` to see the connected peers
3. Use `seda node peers remove <PEER_ID>` to remove a peer (PEER_ID can be found by using list)
4. Use `seda node peers list` to see that it has been removed
5. Use `seda node peers add <MULTI_ADDR>` to add the peer back again (MULTI_ADDR) can be found in the logs from the other node. (looks like "/ip4/172.19.0.2/tcp/44681")