### PR TITLE
feat(p2p): Add s/Kademlia walks to discovery methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,6 +2512,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dns",
  "libp2p-gossipsub",
+ "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
@@ -2605,6 +2606,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-kad"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
+dependencies = [
+ "arrayvec 0.7.2",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "smallvec",
+ "thiserror",
+ "uint",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
 name = "libp2p-mdns"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2661,7 @@ checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
 dependencies = [
  "libp2p-core",
  "libp2p-gossipsub",
+ "libp2p-kad",
  "libp2p-swarm",
  "prometheus-client",
 ]

--- a/cli/src/cli/commands/node/peers/discover.rs
+++ b/cli/src/cli/commands/node/peers/discover.rs
@@ -1,0 +1,20 @@
+use clap::Args;
+use jsonrpsee::{core::client::ClientT, rpc_params, ws_client::WsClientBuilder};
+use seda_config::AppConfig;
+
+use crate::Result;
+
+#[derive(Debug, Args)]
+pub struct DiscoverPeers;
+
+impl DiscoverPeers {
+    pub async fn handle(self, config: AppConfig) -> Result<()> {
+        let client = WsClientBuilder::default()
+            .build(format!("ws://{}", &config.seda_server_url))
+            .await?;
+
+        client.request("discover_peers", rpc_params!()).await?;
+
+        Ok(())
+    }
+}

--- a/cli/src/cli/commands/node/peers/mod.rs
+++ b/cli/src/cli/commands/node/peers/mod.rs
@@ -4,6 +4,7 @@ use seda_config::AppConfig;
 use crate::Result;
 
 mod add;
+mod discover;
 mod list;
 mod remove;
 
@@ -15,6 +16,8 @@ pub enum Peers {
     List(list::ListPeers),
     /// Removes a connected peer
     Remove(remove::RemovePeer),
+    /// Triggers the node to discover more peers
+    Discover(discover::DiscoverPeers),
 }
 
 impl Peers {
@@ -23,6 +26,7 @@ impl Peers {
             Self::Add(add_peer) => add_peer.handle(config).await,
             Self::List(list_peers) => list_peers.handle(config).await,
             Self::Remove(remove_peer) => remove_peer.handle(config).await,
+            Self::Discover(discover_peers) => discover_peers.handle(config).await,
         }
     }
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -35,6 +35,9 @@ pub trait Rpc {
 
     #[method(name = "remove_peer")]
     async fn remove_peer(&self, peer_id: String) -> Result<(), Error>;
+
+    #[method(name = "discover_peers")]
+    async fn discover_peers(&self) -> Result<(), Error>;
 }
 
 pub struct CliServer<HA: HostAdapter> {
@@ -90,6 +93,15 @@ impl<HA: HostAdapter> RpcServer for CliServer<HA> {
 
         self.p2p_command_sender_channel
             .send(P2PCommand::RemovePeer(RemovePeerCommand { peer_id }))
+            .await
+            .map_err(|err| Error::Custom(err.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn discover_peers(&self) -> Result<(), Error> {
+        self.p2p_command_sender_channel
+            .send(P2PCommand::DiscoverPeers)
             .await
             .map_err(|err| Error::Custom(err.to_string()))?;
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -15,7 +15,8 @@ libp2p = { workspace = true, features = [
 	"mdns",
 	"tcp",
 	"macros",
-	"async-std"
+	"async-std",
+	"kad"
 ] }
 parking_lot = { workspace = true }
 seda-config = { workspace = true }

--- a/runtime/sdk/src/p2p.rs
+++ b/runtime/sdk/src/p2p.rs
@@ -28,4 +28,5 @@ pub enum P2PCommand {
     Unicast(UnicastCommand),
     AddPeer(AddPeerCommand),
     RemovePeer(RemovePeerCommand),
+    DiscoverPeers,
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Implement s/kademlia for peer discovering. This allows us to fill in missing peers in the future (when we build a peer manager)

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Add the kademlia package and add it to the SedaBehaviour. Introduced a new command `seda node peers discover` to trigger a kademlia walk. This command is for now and will probably be removed once the peer manager is in place.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Run 3 instances of the node (on different ports with mDNS disabled) Connect node A with B, and B with C. Ask node A to discover new peers using `seda node peers discover`. you'll see that a connection has been established between node A and C by using node B. 
