### PR TITLE
feat: add `bn254` to runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ seda_log.*
 
 # WASM bins
 **/*.wasm
+
+# DS_Store
+**/.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
- "uint",
+ "uint 0.9.5",
  "unsigned-varint",
  "void",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bn254"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694a2df5ffc5f2e385503b2987d281abeb80e02f3c30acd7de0d3db18794e73"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "substrate-bn",
+ "thiserror",
+]
+
+[[package]]
 name = "borsh"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4976,6 +4989,7 @@ name = "seda-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bn254",
  "futures",
  "lazy_static",
  "parking_lot 0.12.1",
@@ -5005,6 +5019,7 @@ dependencies = [
 name = "seda-runtime-sdk"
 version = "0.1.0"
 dependencies = [
+ "bn254",
  "clap",
  "lazy_static",
  "seda-config",
@@ -5423,6 +5438,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ opt-level = "z"
 actix = "0.13"
 async-trait = "0.1"
 base64 = "0.13"
+bn254 = "0.0"
 borsh = { version = "0.9", default-features = false }
 clap = { version = "4.1", default-features = false }
 clap_complete = { version = "4.1", default-features = false }

--- a/config/src/configs/logger.rs
+++ b/config/src/configs/logger.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
-
-use crate::{env_overwrite, merge_config_cli, Config, Result};
+#[cfg(feature = "cli")]
+use {
+    crate::{env_overwrite, merge_config_cli, Config, Result},
+    serde::{Deserialize, Serialize},
+};
 
 #[cfg(feature = "cli")]
 #[derive(clap::Args, Debug, Clone, Default, Serialize, Deserialize)]

--- a/config/src/configs/main_chain/mod.rs
+++ b/config/src/configs/main_chain/mod.rs
@@ -7,9 +7,12 @@ pub use near::*;
 
 mod another_config;
 pub use another_config::*;
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "cli")]
+use {
+    crate::{Config, Result},
+    serde::{Deserialize, Serialize},
+};
 
-use crate::{Config, Result};
 #[cfg(feature = "cli")]
 #[derive(clap::Args, Debug, Default, Serialize, Deserialize)]
 pub struct PartialChainConfigs {

--- a/config/src/configs/main_chain/near.rs
+++ b/config/src/configs/main_chain/near.rs
@@ -1,6 +1,8 @@
-use serde::{Deserialize, Serialize};
-
-use crate::{env_overwrite, merge_config_cli, Config, ConfigError, Result};
+#[cfg(feature = "cli")]
+use {
+    crate::{env_overwrite, merge_config_cli, Config, ConfigError, Result},
+    serde::{Deserialize, Serialize},
+};
 
 #[cfg(feature = "cli")]
 #[derive(clap::Parser, Debug, Clone, Default, Serialize, Deserialize)]

--- a/config/src/configs/node.rs
+++ b/config/src/configs/node.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "cli")]
 use crate::{env_overwrite, merge_config_cli, Config, ConfigError, Result};
+
 #[cfg(feature = "cli")]
 #[derive(clap::Args)]
 /// The configuration for the seda engine.

--- a/config/src/configs/p2p.rs
+++ b/config/src/configs/p2p.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "cli")]
 use crate::{merge_config_cli, Config, Result};
+
 #[cfg(feature = "cli")]
 #[derive(clap::Args)]
 /// The configuration for the seda engine.

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
+bn254 = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 parking_lot = { workspace = true }

--- a/runtime/core/src/errors.rs
+++ b/runtime/core/src/errors.rs
@@ -57,6 +57,9 @@ pub enum RuntimeError {
 
     #[error("P2P Command Channel Error: {0}")]
     P2PCommandChannelError(#[from] SendError<P2PCommand>),
+
+    #[error("BN254 Error: {0}")]
+    Bn254Error(#[from] bn254::Error),
 }
 
 impl From<InstantiationError> for RuntimeError {

--- a/runtime/core/src/imports.rs
+++ b/runtime/core/src/imports.rs
@@ -258,7 +258,7 @@ pub fn bn254_verify_import_obj(store: &Store, vm_context: VmContext) -> Function
         let signature_obj = bn254::Signature::from_compressed(signature)?;
         let public_key_obj = bn254::PublicKey::from_compressed(public_key)?;
 
-        Ok(bn254::ECDSA::verify(&message, &signature_obj, &public_key_obj)
+        Ok(bn254::ECDSA::verify(message, &signature_obj, &public_key_obj)
             .is_ok()
             .into())
     }

--- a/runtime/sdk/Cargo.toml
+++ b/runtime/sdk/Cargo.toml
@@ -10,6 +10,7 @@ wasm = ["serde_json"]
 full = []
 
 [dependencies]
+bn254 = { workspace = true }
 clap = { workspace = true, features = ["derive", "std"] }
 lazy_static = { workspace = true }
 seda-config = { workspace = true }

--- a/runtime/sdk/src/wasm/bn254.rs
+++ b/runtime/sdk/src/wasm/bn254.rs
@@ -1,0 +1,28 @@
+pub use bn254::{PrivateKey as Bn254PrivateKey, PublicKey as Bn254PublicKey, Signature as Bn254Signature};
+
+use super::raw;
+
+pub fn bn254_verify(message: &[u8], signature: &Bn254Signature, public_key: &Bn254PublicKey) -> bool {
+    let message_len = message.len() as i64;
+    let signature_bytes = signature.to_compressed().expect("Signature should be valid");
+    let signature_length = signature_bytes.len() as i64;
+    let public_key_bytes = public_key.to_compressed().expect("Public Key should be valid");
+    let public_key_length = public_key_bytes.len() as i64;
+
+    let result = unsafe {
+        raw::bn254_verify(
+            message.as_ptr(),
+            message_len,
+            signature_bytes.as_ptr(),
+            signature_length,
+            public_key_bytes.as_ptr(),
+            public_key_length,
+        )
+    };
+
+    match result {
+        0 => false,
+        1 => true,
+        _ => panic!("Bn254 verify returned invalid bool in u8: {}", result),
+    }
+}

--- a/runtime/sdk/src/wasm/bn254.rs
+++ b/runtime/sdk/src/wasm/bn254.rs
@@ -26,3 +26,26 @@ pub fn bn254_verify(message: &[u8], signature: &Bn254Signature, public_key: &Bn2
         _ => panic!("Bn254 verify returned invalid bool in u8: {}", result),
     }
 }
+
+pub fn bn254_sign(message: &[u8], private_key: &Bn254PrivateKey) -> Bn254Signature {
+    let message_len = message.len() as i64;
+    let private_key_bytes = private_key.to_bytes().expect("Private key should be valid");
+    let private_key_length = private_key_bytes.len() as i64;
+
+    // Compressed Signatures in G1 have a length of 33 bytes
+    let value_len = 33;
+    let mut result_data_ptr = vec![0; value_len as usize];
+
+    unsafe {
+        raw::bn254_sign(
+            message.as_ptr(),
+            message_len,
+            private_key_bytes.as_ptr(),
+            private_key_length,
+            result_data_ptr.as_mut_ptr(),
+            value_len,
+        )
+    };
+
+    Bn254Signature::from_compressed(result_data_ptr).expect("Signature should be valid")
+}

--- a/runtime/sdk/src/wasm/mod.rs
+++ b/runtime/sdk/src/wasm/mod.rs
@@ -1,3 +1,4 @@
+mod bn254;
 mod call;
 #[cfg(feature = "full")]
 mod chain_interactor;
@@ -25,3 +26,5 @@ pub use memory::*;
 #[cfg(feature = "full")]
 pub use p2p::*;
 pub use promise::*;
+
+pub use self::bn254::*;

--- a/runtime/sdk/src/wasm/raw.rs
+++ b/runtime/sdk/src/wasm/raw.rs
@@ -22,4 +22,12 @@ extern "C" {
         public_key: *const u8,
         public_key_length: i64,
     ) -> u8;
+    pub fn bn254_sign(
+        message: *const u8,
+        message_length: i64,
+        private_key: *const u8,
+        private_key_length: i64,
+        result_data_ptr: *const u8,
+        result_data_length: i64,
+    );
 }

--- a/runtime/sdk/src/wasm/raw.rs
+++ b/runtime/sdk/src/wasm/raw.rs
@@ -14,4 +14,12 @@ extern "C" {
         line_info: *const u8,
         line_info_len: i64,
     );
+    pub fn bn254_verify(
+        message: *const u8,
+        message_length: i64,
+        signature: *const u8,
+        signature_length: i64,
+        public_key: *const u8,
+        public_key_length: i64,
+    ) -> u8;
 }

--- a/wasm/test/promise-wasm-bin/src/main.rs
+++ b/wasm/test/promise-wasm-bin/src/main.rs
@@ -180,6 +180,6 @@ fn encode_hex(bytes: &[u8]) -> String {
     for &b in bytes {
         write!(&mut result, "{:02x}", b).unwrap();
     }
-    
+
     result
 }


### PR DESCRIPTION
## Motivation

We support of `bn254` functions from the WASM SDK in order to sign and verify aggregate signatures.

## Explanation of Changes

Added `bn254` verify and sign function to the runtime core and the SDK:
- `bn254_verify`
- `bn254_sign`

SDK functions expose the `bn254` types to be more ergonomic.

## Testing

Added:
- functions in the `promise-wasm-bin` for verifying and signing.
- tests in `runtime_test.rs` using that VM for checking that `bn254` functions work properly

## Related PRs and Issues

I used `to_compressed` and `from_uncompressed` methods but we might want to use the "uncompressed" versions as I believe we might prefer lower computation over data length. However, uncompressed methods are not (yet) available for G1.