### PR TITLE
feat: create a random key on node startup if not found in env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 SEDA_LOG_FILE_PATH = "some path of where to store seda log files"
 SEDA_NEAR_RPC_URL = "https://rpc.testnet.near.org"
+CHAIN_SECRET_KEY = "some secret key"
 SEDA_SECRET_KEY = "some secret key"
 SEDA_SERVER_ADDRESS = "127.0.0.1"
 SEDA_SERVER_PORT = 12345

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 SEDA_LOG_FILE_PATH = "some path of where to store seda log files"
 SEDA_NEAR_RPC_URL = "https://rpc.testnet.near.org"
-CHAIN_SECRET_KEY = "some secret key"
+SEDA_CHAIN_SECRET_KEY = "some secret key"
 SEDA_SECRET_KEY = "some secret key"
 SEDA_SERVER_ADDRESS = "127.0.0.1"
 SEDA_SERVER_PORT = 12345

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ seda_log.*
 
 # DS_Store
 **/.DS_Store
+
+# Randomly generated secret key
+seda_key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5020,9 +5020,11 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "async-trait",
+ "borsh",
  "futures",
  "jsonrpsee",
  "parking_lot 0.12.1",
+ "rand 0.8.5",
  "reqwest",
  "rusqlite",
  "seda-chains",
@@ -5036,6 +5038,7 @@ dependencies = [
  "tokio",
  "tokio-rusqlite",
  "tracing",
+ "zeropool-bn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5020,6 +5020,7 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "async-trait",
+ "bn254",
  "borsh",
  "futures",
  "jsonrpsee",
@@ -5038,7 +5039,6 @@ dependencies = [
  "tokio",
  "tokio-rusqlite",
  "tracing",
- "zeropool-bn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.2",
+ "gimli 0.27.1",
 ]
 
 [[package]]
@@ -169,7 +169,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -621,9 +621,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
  "memchr",
  "serde",
@@ -676,9 +676,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytesize"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "bzip2"
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.1.3"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0012995dc3a54314f4710f5631d74767e73c534b8757221708303e48eef7a19b"
+checksum = "3d6540eedc41f8a5a76cf3d8d458057dcdf817be4158a55b5f861f7a5483de75"
 dependencies = [
  "clap",
 ]
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "bc831ee6a32dd495436e317595e639a587aa9907bef96fe6e6abc290ab6204e9"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "94331d54f1b1a8895cd81049f7eaaaef9d05a7dcb4d1fd08bf3ff0806246789d"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1192,15 +1192,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "48dcd35ba14ca9b40d6e4b4b39961f23d835dbb8eed74565ded361d93e1feb8a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "81bbeb29798b407ccd82a3324ade1a7286e0d29851475990b612670f6f5124d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1558,9 +1558,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "globset"
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -2251,9 +2251,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -2522,7 +2522,7 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.8",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-kad",
@@ -2533,7 +2533,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
- "multiaddr 0.16.0",
+ "multiaddr",
  "parking_lot 0.12.1",
  "pin-project",
  "smallvec",
@@ -2554,42 +2554,8 @@ dependencies = [
  "futures-timer",
  "instant",
  "log",
- "multiaddr 0.16.0",
- "multihash 0.16.3",
- "multistream-select",
- "once_cell",
- "parking_lot 0.12.1",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "rw-stream-sink",
- "sec1",
- "sha2 0.10.6",
- "smallvec",
- "thiserror",
- "unsigned-varint",
- "void",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881d9a54e97d97cdaa4125d48269d97ca8c40e5fefec6b85b30440dc60cc551f"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "log",
- "multiaddr 0.17.0",
- "multihash 0.17.0",
+ "multiaddr",
+ "multihash",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
@@ -2615,7 +2581,7 @@ checksum = "8e42a271c1b49f789b92f7fc87749fa79ce5c7bdc88cbdfacb818a4bca47fec5"
 dependencies = [
  "async-std-resolver",
  "futures",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
  "parking_lot 0.12.1",
  "smallvec",
@@ -2636,7 +2602,7 @@ dependencies = [
  "futures",
  "hex_fmt",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-swarm",
  "log",
  "prometheus-client",
@@ -2666,7 +2632,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-swarm",
  "log",
  "prost",
@@ -2690,7 +2656,7 @@ dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
@@ -2706,7 +2672,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
 dependencies = [
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-gossipsub",
  "libp2p-kad",
  "libp2p-swarm",
@@ -2722,7 +2688,7 @@ dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
  "once_cell",
  "prost",
@@ -2738,16 +2704,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha.2"
+version = "0.7.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971f629ff7519f4d4889a7c981f0dc09c6ad493423cd8a13ee442de241bc8c8"
+checksum = "01e7c867e95c8130667b24409d236d37598270e6da69b3baf54213ba31ffca59"
 dependencies = [
  "async-std",
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.39.0",
+ "libp2p-core",
  "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
@@ -2769,7 +2735,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "libp2p-swarm-derive",
  "log",
  "pin-project",
@@ -2801,20 +2767,20 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
  "socket2",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9baf6f6292149e124ee737d9a79dbee783f29473fc368c7faad9d157841078a"
+checksum = "f7905ce0d040576634e8a3229a7587cc8beab83f79db6023800f1792895defa8"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.39.0",
+ "libp2p-core",
  "rcgen",
  "ring",
  "rustls",
@@ -2831,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f63594a0aa818642d9d4915c791945053877253f08a3626f13416b5cd928a29"
 dependencies = [
  "futures",
- "libp2p-core 0.38.0",
+ "libp2p-core",
  "log",
  "parking_lot 0.12.1",
  "thiserror",
@@ -2970,9 +2936,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
 dependencies = [
  "libc",
 ]
@@ -3018,14 +2984,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3044,25 +3010,7 @@ dependencies = [
  "byteorder",
  "data-encoding",
  "multibase",
- "multihash 0.16.3",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
-name = "multiaddr"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b53e0cc5907a5c216ba6584bf74be8ab47d6d6289f72793b2dddbf15dc3bf8c"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "multibase",
- "multihash 0.17.0",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -3086,19 +3034,6 @@ name = "multihash"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
-dependencies = [
- "core2",
- "digest 0.10.6",
- "multihash-derive",
- "sha2 0.10.6",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "core2",
  "digest 0.10.6",
@@ -3789,9 +3724,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -4206,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4216,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
  "bytes",
  "heck",
@@ -4251,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4264,10 +4199,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
+ "bytes",
  "prost",
 ]
 
@@ -4431,7 +4367,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.17",
  "yasna",
 ]
 
@@ -4541,9 +4477,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.4.0"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
 dependencies = [
  "bytecheck",
 ]
@@ -4621,9 +4557,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.40"
+version = "0.7.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
+checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
@@ -4635,9 +4571,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.40"
+version = "0.7.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
+checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5284,9 +5220,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -5294,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -5315,9 +5251,9 @@ checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
@@ -5521,9 +5457,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5582,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "tempfile"
@@ -5631,11 +5567,10 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
- "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -5667,14 +5602,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
  "serde",
  "time-core",
- "time-macros 0.2.8",
+ "time-macros 0.2.6",
 ]
 
 [[package]]
@@ -5695,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -5806,9 +5741,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5817,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5882,7 +5817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.20",
+ "time 0.3.17",
  "tracing-subscriber",
 ]
 
@@ -6831,7 +6766,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -6863,7 +6798,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
- "time 0.3.20",
+ "time 0.3.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ async-trait = "0.1"
 base64 = "0.13"
 bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
 borsh = { version = "0.9", default-features = false }
+bn254 = "0.0.1"
 clap = { version = "4.1", default-features = false }
 clap_complete = { version = "4.1", default-features = false }
 clap-markdown = { version = "0.1", default-features = false }
@@ -89,4 +90,3 @@ uint = { version = "0.8", default-features = false }
 wasmer = { version = "2.3", default-features = false }
 wasmer-wasi = { version = "2.3", default-features = false }
 workspaces = "0.7"
-zeropool-bn = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ near-primitives = "0.15"
 near-sdk = { version = "4.0", default-features = false }
 near-units = "0.2"
 parking_lot = "0.12"
+rand = "0.8.5"
 reqwest = "0.11"
 rusqlite = { version = "0.28", features = ["bundled"] }
 schemars = "0.8"
@@ -88,3 +89,4 @@ uint = { version = "0.8", default-features = false }
 wasmer = { version = "2.3", default-features = false }
 wasmer-wasi = { version = "2.3", default-features = false }
 workspaces = "0.7"
+zeropool-bn = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ async-trait = "0.1"
 base64 = "0.13"
 bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
 borsh = { version = "0.9", default-features = false }
-bn254 = "0.0.1"
 clap = { version = "4.1", default-features = false }
 clap_complete = { version = "4.1", default-features = false }
 clap-markdown = { version = "0.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ SEDA configuration uses the following ENV variables if they exist.
 | `SEDA_CONFIG_PATH`    | Defines an alternative path for the seda configuration file to be.                                                                 |
 | `SEDA_LOG_FILE_PATH`  | Overwrites the config `logging.log_file_path` field.                                                                               |
 | `SEDA_NEAR_RPC_URL`   | Overwrites the config `near_chain.chain_rpc_url` field.                                                                            |
-| `SEDA_SECRET_KEY`     | Overwrites the config `node.secret_key` field.                                                                                     |
+| `CHAIN_SECRET_KEY`     | Overwrites the config `node.secret_key` field.                                                                                     |
 | `SEDA_SERVER_ADDRESS` | Overwrites the config `seda_server_address` field.                                                                                 |
 | `SEDA_SERVER_PORT`    | Overwrites the config `seda_server_port` field.                                                                                    |
 | `RUST_LOG`            | Controlled via the [tracing_subscriber](https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/struct.EnvFilter.html) crate. |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ You can look at the example configuration [here](example.config.toml).
   - public_key(\*) - Your near public key.
   - runtime_worker_threads(?\*) - The number of threads the node can use to spin
     up jobs.
-  - secret_key(!\*) - Your near secret key.
+  - seda_chain_secret_key(!\*) - Your near secret key.
+  - seda_secret_key(!\*) - Your node secret key.
+  - seda_secret_key_file_path(!\*) - Your node secret key file path.
   - signer_account_id(\*) - Your near signer account id.
 - logging - All config fields related to the seda logger.
   - log_file_path(?!\*) - The path where the log file will write.
@@ -100,7 +102,8 @@ SEDA configuration uses the following ENV variables if they exist.
 | `SEDA_CONFIG_PATH`    | Defines an alternative path for the seda configuration file to be.                                                                 |
 | `SEDA_LOG_FILE_PATH`  | Overwrites the config `logging.log_file_path` field.                                                                               |
 | `SEDA_NEAR_RPC_URL`   | Overwrites the config `near_chain.chain_rpc_url` field.                                                                            |
-| `CHAIN_SECRET_KEY`     | Overwrites the config `node.secret_key` field.                                                                                     |
+| `SEDA_CHAIN_SECRET_KEY`     | Overwrites the config `node.seda_chain_secret_key` field.       
+| `SEDA_SECRET_KEY`     | Overwrites the config `node.seda_secret_key` field.                                                                               |
 | `SEDA_SERVER_ADDRESS` | Overwrites the config `seda_server_address` field.                                                                                 |
 | `SEDA_SERVER_PORT`    | Overwrites the config `seda_server_port` field.                                                                                    |
 | `RUST_LOG`            | Controlled via the [tracing_subscriber](https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/struct.EnvFilter.html) crate. |

--- a/cli/src/cli/commands/mod.rs
+++ b/cli/src/cli/commands/mod.rs
@@ -32,7 +32,7 @@ pub(crate) async fn call<T: DeserializeOwned + Serialize>(
     let signed_txn = chain::construct_signed_tx(
         chain,
         &node_config.signer_account_id,
-        &node_config.secret_key,
+        &node_config.seda_chain_secret_key,
         contract_id,
         method_name,
         args.into_bytes(),

--- a/config/src/configs/node.rs
+++ b/config/src/configs/node.rs
@@ -107,7 +107,7 @@ impl Config for PartialNodeConfig {
     }
 
     fn overwrite_from_env(&mut self) {
-        env_overwrite!(self.secret_key, "SEDA_SECRET_KEY");
+        env_overwrite!(self.secret_key, "CHAIN_SECRET_KEY");
     }
 }
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -9,7 +9,10 @@ chain_rpc_url = 'https://rpc.testnet.near.org'
 [node]
 contract_account_id = 'fill this in'
 public_key = 'fill this in'
-secret_key = 'fill this in'
+seda_chain_secret_key = 'fill this in'
+seda_secret_key = 'fill this in'
+seda_secret_key_file_path = 'fill this in'
+
 signer_account_id = 'fill this in'
 
 [logging]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,9 +7,11 @@ rust-version.workspace = true
 [dependencies]
 actix = { workspace = true }
 async-trait = { workspace = true }
+borsh = { workspace = true }
 futures = { workspace = true }
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 parking_lot = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
 rusqlite = { workspace = true }
 seda-chains = { workspace = true }
@@ -23,3 +25,4 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rusqlite = { workspace = true }
 tracing = { workspace = true }
+zeropool-bn = { workspace = true }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 [dependencies]
 actix = { workspace = true }
 async-trait = { workspace = true }
+bn254 = { workspace = true }
 borsh = { workspace = true }
 futures = { workspace = true }
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
@@ -25,4 +26,3 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rusqlite = { workspace = true }
 tracing = { workspace = true }
-zeropool-bn = { workspace = true }

--- a/node/src/generate_sk.rs
+++ b/node/src/generate_sk.rs
@@ -1,0 +1,15 @@
+use std::{fs::File, io::Write};
+
+use bn254::PrivateKey;
+use seda_config::NodeConfig;
+
+pub fn generate_secret_key(config: NodeConfig) {
+    // Checks if there is a SEDA_SECRET_KEY env variable
+    // If not, it generates a new random one and saves it into a file
+    if std::env::var("SEDA_SECRET_KEY").is_err() && config.seda_secret_key.is_empty() {
+        let rng = &mut rand::thread_rng();
+        let sk = PrivateKey::random(rng);
+        let mut file = File::create(config.seda_secret_key_file_path.clone()).expect("Unable to create file");
+        writeln!(file, "{:?}", sk.to_bytes().expect("couldn't serialize sk")).expect("Unable to write secret key");
+    }
+}

--- a/node/src/host/chain_call.rs
+++ b/node/src/host/chain_call.rs
@@ -28,7 +28,7 @@ impl ChainCall {
         let signed_txn = chain::construct_signed_tx(
             self.chain,
             &self.node_config.signer_account_id,
-            &self.node_config.secret_key,
+            &self.node_config.seda_chain_secret_key,
             &self.contract_id,
             &self.method_name,
             self.args,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -31,7 +31,6 @@ use generate_sk::generate_secret_key;
 pub mod test {
     mod event_queue_test;
 }
-const SK_PATH: &str = "./seda_key";
 pub fn run(seda_server_address: &str, config: NodeConfig, p2p_config: P2PConfig, chain_configs: ChainConfigs) {
     let system = System::new();
     // Initialize actors inside system context

--- a/runtime/core/src/test_host.rs
+++ b/runtime/core/src/test_host.rs
@@ -77,7 +77,7 @@ impl HostAdapter for RuntimeTestAdapter {
         let signed_txn = chain::construct_signed_tx(
             chain,
             &node_config.signer_account_id,
-            &node_config.secret_key,
+            &node_config.seda_chain_secret_key,
             contract_id,
             method_name,
             args,


### PR DESCRIPTION
- Renames the preexisting `SEDA_SECRECT_KEY` to `CHAIN_SECRET_KEY`.
- Checks for a `SEDA_SECRET_KEY` in .env, if not found it generates a random secret key using `rand` and `bn254` crates, then writes it to a file `random_sk`

