### PR TITLE
Feat/promise rejections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.59+curl-7.86.0"
+version = "0.4.60+curl-7.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
+checksum = "717abe2cb465a5da6ce06617388a3980c9a2844196734bec8ccb8e575250f13f"
 dependencies = [
  "cc",
  "libc",
@@ -5025,6 +5025,7 @@ dependencies = [
  "seda-config",
  "serde",
  "serde_json",
+ "thiserror",
  "tracing",
 ]
 

--- a/contracts/mainchain/src/node_registry_test.rs
+++ b/contracts/mainchain/src/node_registry_test.rs
@@ -131,7 +131,7 @@ fn get_nodes() {
 
     // check the latest 3 nodes
     let latest_3_nodes = contract.get_nodes(U64(100), U64(0));
-    assert_eq!(latest_3_nodes, vec![node3.clone(), node2.clone(), node1.clone()]);
+    assert_eq!(latest_3_nodes, vec![node3, node2.clone(), node1.clone()]);
 
     // check offset of 1
     let latest_nodes_offset = contract.get_nodes(U64(100), U64(1));

--- a/contracts/seda-token/src/lib.rs
+++ b/contracts/seda-token/src/lib.rs
@@ -129,7 +129,7 @@ mod tests {
     fn test_new() {
         let mut context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
+        let contract = Contract::new_default_meta(accounts(1), TOTAL_SUPPLY.into());
         testing_env!(context.is_view(true).build());
         assert_eq!(contract.ft_total_supply().0, TOTAL_SUPPLY);
         assert_eq!(contract.ft_balance_of(accounts(1)).0, TOTAL_SUPPLY);
@@ -147,7 +147,7 @@ mod tests {
     fn test_transfer() {
         let mut context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = Contract::new_default_meta(accounts(2).into(), TOTAL_SUPPLY.into());
+        let mut contract = Contract::new_default_meta(accounts(2), TOTAL_SUPPLY.into());
         testing_env!(
             context
                 .storage_usage(env::storage_usage())

--- a/contracts/tests/Cargo.toml
+++ b/contracts/tests/Cargo.toml
@@ -12,8 +12,10 @@ near-sdk = { workspace = true }
 near-contract-standards = { workspace = true }
 near-units = { workspace = true }
 schemars = { workspace = true }
-seda-mainchain = { path = "../mainchain"}
+seda-mainchain = { path = "../mainchain" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
 workspaces = { workspace = true }

--- a/contracts/tests/src/lib.rs
+++ b/contracts/tests/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(target_family = "unix")]
 mod seda_token;
+#[cfg(target_family = "unix")]
 mod staking;
+#[cfg(target_family = "unix")]
 mod utils;

--- a/runtime/core/src/errors.rs
+++ b/runtime/core/src/errors.rs
@@ -1,10 +1,11 @@
 use std::num::ParseIntError;
 
-use seda_runtime_sdk::p2p::P2PCommand;
+use seda_runtime_sdk::{p2p::P2PCommand, SDKError};
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 use wasmer::{CompileError, ExportError, InstantiationError};
 use wasmer_wasi::{FsError, WasiError, WasiStateCreationError};
+
 #[derive(Debug, Error)]
 pub enum RuntimeError {
     #[error(transparent)]
@@ -34,15 +35,7 @@ pub enum RuntimeError {
     IoError(#[from] std::io::Error),
 
     #[error(transparent)]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
-
-    #[error(transparent)]
     ParseIntError(#[from] ParseIntError),
-
-    #[error("{0:?}")]
-    StringBytesConversion(#[from] std::str::Utf8Error),
-    #[error("{0}")]
-    NumBytesConversion(#[from] std::array::TryFromSliceError),
 
     // TODO this is scuffed and not true for test_host.
     #[error("Node Error: {0}")]
@@ -60,6 +53,9 @@ pub enum RuntimeError {
 
     #[error("BN254 Error: {0}")]
     Bn254Error(#[from] bn254::Error),
+
+    #[error("SDK Error: {0}")]
+    SDKError(#[from] SDKError),
 }
 
 impl From<InstantiationError> for RuntimeError {

--- a/runtime/core/src/host_adapter.rs
+++ b/runtime/core/src/host_adapter.rs
@@ -6,7 +6,7 @@ use seda_runtime_sdk::{events::Event, Chain};
 
 #[async_trait::async_trait]
 pub trait HostAdapter: Send + Sync + Unpin + 'static {
-    type Error: Display;
+    type Error: Display + std::error::Error;
 
     async fn new(config: ChainConfigs) -> Result<Self, Self::Error>
     where

--- a/runtime/core/src/runtime.rs
+++ b/runtime/core/src/runtime.rs
@@ -27,6 +27,13 @@ pub struct VmResult {
     pub exit_code: u8,
 }
 
+// TODO: can I move this trait to the sdk?
+// only expose during non wasm compilation.
+// purely allows for clean up of implementations of said trait.
+// Ah but then the HostAdapter stuff all needs to be folded into this trait, or
+// something similar.
+// Probably should be done but in another PR.
+// PS> CallSelf would be a pain >.<
 #[async_trait::async_trait]
 pub trait RunnableRuntime {
     async fn new(node_config: NodeConfig, chains_config: ChainConfigs, limited: bool) -> Result<Self>
@@ -158,6 +165,8 @@ impl<HA: HostAdapter> RunnableRuntime for Runtime<HA> {
                             output.push(stderr_buffer);
                         }
 
+                        // TODO @gluax: test if this should be a rejection as well.
+                        // I think it should be.
                         // Unwrap the error here after capturing the output
                         // otherwise the output would get lost
                         if let Err(err) = runtime_result {

--- a/runtime/core/src/runtime.rs
+++ b/runtime/core/src/runtime.rs
@@ -27,13 +27,6 @@ pub struct VmResult {
     pub exit_code: u8,
 }
 
-// TODO: can I move this trait to the sdk?
-// only expose during non wasm compilation.
-// purely allows for clean up of implementations of said trait.
-// Ah but then the HostAdapter stuff all needs to be folded into this trait, or
-// something similar.
-// Probably should be done but in another PR.
-// PS> CallSelf would be a pain >.<
 #[async_trait::async_trait]
 pub trait RunnableRuntime {
     async fn new(node_config: NodeConfig, chains_config: ChainConfigs, limited: bool) -> Result<Self>
@@ -222,7 +215,7 @@ impl<HA: HostAdapter> RunnableRuntime for Runtime<HA> {
                             .into();
                     }
                     PromiseAction::P2PBroadcast(p2p_broadcast_action) => {
-                        // TODO we need to figure this out at some point.
+                        // TODO we need to figure out how to handle success and errors using channels.
                         p2p_command_sender_channel
                             .send(P2PCommand::Broadcast(p2p_broadcast_action.data.clone()))
                             .await?;

--- a/runtime/core/src/runtime.rs
+++ b/runtime/core/src/runtime.rs
@@ -2,7 +2,7 @@ use std::{io::Read, sync::Arc};
 
 use parking_lot::Mutex;
 use seda_config::{ChainConfigs, NodeConfig};
-use seda_runtime_sdk::{p2p::P2PCommand, CallSelfAction, Promise, PromiseAction, PromiseStatus};
+use seda_runtime_sdk::{p2p::P2PCommand, CallSelfAction, FromBytes, Promise, PromiseAction, PromiseStatus};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::Sender;
 use tracing::info;
@@ -173,7 +173,7 @@ impl<HA: HostAdapter> RunnableRuntime for Runtime<HA> {
                     // Just an example, delete this later
                     PromiseAction::DatabaseSet(db_action) => {
                         self.host_adapter
-                            .db_set(&db_action.key, &String::from_utf8(db_action.value.clone())?)
+                            .db_set(&db_action.key, &String::from_bytes(&db_action.value)?)
                             .await
                             .map_err(|e| RuntimeError::NodeError(e.to_string()))?;
 

--- a/runtime/core/src/storage/in_memory_adapter.rs
+++ b/runtime/core/src/storage/in_memory_adapter.rs
@@ -13,7 +13,7 @@ impl MemoryAdapter for InMemory {
     where
         O: FromBytes,
     {
-        self.memory.get(key).map(|b| O::from_bytes(b.deref())).transpose()
+        Ok(self.memory.get(key).map(|b| O::from_bytes(b.deref())).transpose()?)
     }
 
     fn put<V>(&mut self, key: &str, value: V) -> Option<Bytes>

--- a/runtime/core/src/storage/mod.rs
+++ b/runtime/core/src/storage/mod.rs
@@ -1,11 +1,9 @@
-mod bytes;
-pub use bytes::*;
-
 mod in_memory_adapter;
 pub use in_memory_adapter::*;
 
 mod memory_adapter;
 pub use memory_adapter::*;
+pub(crate) use seda_runtime_sdk::{Bytes, FromBytes, ToBytes};
 
 #[cfg(test)]
 #[path = ""]

--- a/runtime/sdk/Cargo.toml
+++ b/runtime/sdk/Cargo.toml
@@ -16,4 +16,5 @@ lazy_static = { workspace = true }
 seda-config = { workspace = true }
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, optional = true, features = ["std"] }
+thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/runtime/sdk/src/bytes.rs
+++ b/runtime/sdk/src/bytes.rs
@@ -55,7 +55,7 @@ impl ToBytes for &str {
 /// [crate::PromiseStatus]
 impl ToBytes for () {
     fn to_bytes(self) -> Bytes {
-        "Promise success".to_string().to_bytes()
+        Bytes::default()
     }
 }
 

--- a/runtime/sdk/src/bytes.rs
+++ b/runtime/sdk/src/bytes.rs
@@ -7,6 +7,12 @@ use crate::Result;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bytes(Vec<u8>);
 
+impl Bytes {
+    pub fn eject(self) -> Vec<u8> {
+        self.0
+    }
+}
+
 /// We implement Deref over the Bytes type allowing us to avoid a clone for
 /// `FromBytes`.
 impl Deref for Bytes {

--- a/runtime/sdk/src/bytes.rs
+++ b/runtime/sdk/src/bytes.rs
@@ -45,6 +45,12 @@ impl ToBytes for String {
     }
 }
 
+impl ToBytes for &str {
+    fn to_bytes(self) -> Bytes {
+        Bytes(self.as_bytes().to_vec())
+    }
+}
+
 /// For functions that return an `()` to be converted to a
 /// [crate::PromiseStatus]
 impl ToBytes for () {

--- a/runtime/sdk/src/bytes.rs
+++ b/runtime/sdk/src/bytes.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bytes(Vec<u8>);
 
 impl Bytes {
@@ -42,6 +42,14 @@ impl ToBytes for Vec<u8> {
 impl ToBytes for String {
     fn to_bytes(self) -> Bytes {
         Bytes(self.as_bytes().to_vec())
+    }
+}
+
+/// For functions that return an `()` to be converted to a
+/// [crate::PromiseStatus]
+impl ToBytes for () {
+    fn to_bytes(self) -> Bytes {
+        "Promise success".to_string().to_bytes()
     }
 }
 

--- a/runtime/sdk/src/errors.rs
+++ b/runtime/sdk/src/errors.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SDKError {
+    #[error(transparent)]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+
+    #[error("{0:?}")]
+    StringBytesConversion(#[from] std::str::Utf8Error),
+
+    #[error(transparent)]
+    NumBytesConversion(#[from] std::array::TryFromSliceError),
+}
+
+pub type Result<T, E = SDKError> = core::result::Result<T, E>;

--- a/runtime/sdk/src/lib.rs
+++ b/runtime/sdk/src/lib.rs
@@ -1,7 +1,11 @@
 mod chain;
 pub use chain::Chain;
+mod errors;
+pub use errors::*;
 mod level;
 pub use level::Level;
+mod bytes;
+pub use bytes::*;
 pub mod p2p;
 mod promises;
 

--- a/runtime/sdk/src/promises/actions.rs
+++ b/runtime/sdk/src/promises/actions.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{events::Event, Chain};
 
+// TODO: all action types with Vec<u8> can just be the Bytes type.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PromiseAction {
     CallSelf(CallSelfAction),

--- a/runtime/sdk/src/promises/promise.rs
+++ b/runtime/sdk/src/promises/promise.rs
@@ -13,7 +13,7 @@ pub enum PromiseStatus {
     Pending,
 
     /// The promise completed
-    Fulfilled(Vec<u8>),
+    Fulfilled(Option<Vec<u8>>),
 
     /// There was an error executing this promise
     // TODO: Is there ever a case where Rejected isn't a string?
@@ -24,7 +24,16 @@ pub enum PromiseStatus {
 impl<T: crate::ToBytes, E: std::error::Error> From<Result<T, E>> for PromiseStatus {
     fn from(value: Result<T, E>) -> Self {
         match value {
-            Ok(fulfilled) => PromiseStatus::Fulfilled(fulfilled.to_bytes().eject()),
+            Ok(fulfilled) => PromiseStatus::Fulfilled(Some(fulfilled.to_bytes().eject())),
+            Err(rejection) => PromiseStatus::Rejected(rejection.to_string().to_bytes().eject()),
+        }
+    }
+}
+
+impl<T: crate::ToBytes, E: std::error::Error> From<Result<Option<T>, E>> for PromiseStatus {
+    fn from(value: Result<Option<T>, E>) -> Self {
+        match value {
+            Ok(fulfilled) => PromiseStatus::Fulfilled(fulfilled.map(|inner| inner.to_bytes().eject())),
             Err(rejection) => PromiseStatus::Rejected(rejection.to_string().to_bytes().eject()),
         }
     }

--- a/runtime/sdk/src/promises/promise.rs
+++ b/runtime/sdk/src/promises/promise.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::PromiseAction;
 use crate::ToBytes;
 
+// TODO: Fulfilled and Rejected could now just be our Bytes type.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PromiseStatus {
     /// Initial state
@@ -15,6 +16,8 @@ pub enum PromiseStatus {
     Fulfilled(Vec<u8>),
 
     /// There was an error executing this promise
+    // TODO: Is there ever a case where Rejected isn't a string?
+    // Could private the type and then have methods or something.
     Rejected(Vec<u8>),
 }
 

--- a/runtime/sdk/src/promises/promise.rs
+++ b/runtime/sdk/src/promises/promise.rs
@@ -17,6 +17,7 @@ pub enum PromiseStatus {
 
     /// There was an error executing this promise
     // TODO: Is there ever a case where Rejected isn't a string?
+    // HTTP rejections could be an object(but encoded in a string).
     // Could private the type and then have methods or something.
     Rejected(Vec<u8>),
 }

--- a/runtime/sdk/src/promises/promise.rs
+++ b/runtime/sdk/src/promises/promise.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::PromiseAction;
+use crate::ToBytes;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PromiseStatus {
@@ -17,11 +18,11 @@ pub enum PromiseStatus {
     Rejected(Vec<u8>),
 }
 
-impl<T: crate::ToBytes, E: crate::ToBytes> From<Result<T, E>> for PromiseStatus {
+impl<T: crate::ToBytes, E: std::error::Error> From<Result<T, E>> for PromiseStatus {
     fn from(value: Result<T, E>) -> Self {
         match value {
             Ok(fulfilled) => PromiseStatus::Fulfilled(fulfilled.to_bytes().eject()),
-            Err(rejection) => PromiseStatus::Rejected(rejection.to_bytes().eject()),
+            Err(rejection) => PromiseStatus::Rejected(rejection.to_string().to_bytes().eject()),
         }
     }
 }

--- a/runtime/sdk/src/promises/promise.rs
+++ b/runtime/sdk/src/promises/promise.rs
@@ -17,6 +17,15 @@ pub enum PromiseStatus {
     Rejected(Vec<u8>),
 }
 
+impl<T: crate::ToBytes, E: crate::ToBytes> From<Result<T, E>> for PromiseStatus {
+    fn from(value: Result<T, E>) -> Self {
+        match value {
+            Ok(fulfilled) => PromiseStatus::Fulfilled(fulfilled.to_bytes().eject()),
+            Err(rejection) => PromiseStatus::Rejected(rejection.to_bytes().eject()),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Promise {
     /// The name of the action we should execute

--- a/runtime/sdk/src/wasm/memory.rs
+++ b/runtime/sdk/src/wasm/memory.rs
@@ -11,6 +11,8 @@ pub fn memory_read(key: &str) -> Vec<u8> {
     result_data_ptr
 }
 
+// TODO: Value could be cleaned up to a generic that implements our ToBytes
+// trait :)
 pub fn memory_write(key: &str, mut value: Vec<u8>) {
     let key_len = key.len() as i64;
     let mut key = key.to_string().into_bytes();

--- a/runtime/sdk/src/wasm/p2p.rs
+++ b/runtime/sdk/src/wasm/p2p.rs
@@ -1,6 +1,8 @@
 use super::Promise;
 use crate::{P2PBroadcastAction, PromiseAction};
 
+// TODO: data could be cleaned up to a generic that implements our ToBytes trait
+// :)
 pub fn p2p_broadcast_message(data: Vec<u8>) -> Promise {
     Promise::new(PromiseAction::P2PBroadcast(P2PBroadcastAction { data }))
 }

--- a/wasm/cli/src/main.rs
+++ b/wasm/cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use seda_runtime_sdk::{
     wasm::{call_self, chain_call, chain_view, db_set, http_fetch, log, p2p_broadcast_message, Promise},
     Chain,
+    FromBytes,
     PromiseStatus,
 };
 
@@ -85,7 +86,7 @@ fn http_fetch_result() {
     let result = Promise::result(0);
 
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_utf8(vec).unwrap(),
+        PromiseStatus::Fulfilled(vec) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
 
@@ -96,7 +97,7 @@ fn http_fetch_result() {
 fn chain_view_test_success() {
     let result = Promise::result(0);
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_utf8(vec).unwrap(),
+        PromiseStatus::Fulfilled(vec) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
     println!("Value: {value_to_store}");
@@ -108,7 +109,7 @@ fn chain_view_test_success() {
 fn chain_call_test_success() {
     let result = Promise::result(0);
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_utf8(vec).unwrap(),
+        PromiseStatus::Fulfilled(vec) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
     println!("Value: {value_to_store}");

--- a/wasm/cli/src/main.rs
+++ b/wasm/cli/src/main.rs
@@ -86,7 +86,7 @@ fn http_fetch_result() {
     let result = Promise::result(0);
 
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_bytes_vec(vec).unwrap(),
+        PromiseStatus::Fulfilled(Some(vec)) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
 
@@ -97,7 +97,7 @@ fn http_fetch_result() {
 fn chain_view_test_success() {
     let result = Promise::result(0);
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_bytes_vec(vec).unwrap(),
+        PromiseStatus::Fulfilled(Some(vec)) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
     println!("Value: {value_to_store}");
@@ -109,7 +109,7 @@ fn chain_view_test_success() {
 fn chain_call_test_success() {
     let result = Promise::result(0);
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_bytes_vec(vec).unwrap(),
+        PromiseStatus::Fulfilled(Some(vec)) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
     println!("Value: {value_to_store}");

--- a/wasm/consensus/src/tasks/bridge.rs
+++ b/wasm/consensus/src/tasks/bridge.rs
@@ -38,7 +38,7 @@ fn bridge_step_1() {
     let deposit = u128::from_bytes_vec(deposit_bytes).unwrap();
     match result {
         // TODO: I wonder if SEDA-188 could also make it so we don't have to do these conversions manually?
-        PromiseStatus::Fulfilled(data) => {
+        PromiseStatus::Fulfilled(Some(data)) => {
             let data = String::from_bytes_vec(data).expect("chain_view resulted in a invalid string");
             let args_string = serde_json::json!({ "data_request": data }).to_string();
             log!(Level::Debug, "Posting args: {args_string}");
@@ -61,7 +61,7 @@ fn bridge_step_2() {
     let result = Promise::result(0);
     println!("{{\"status\": \"success\"}}");
     match result {
-        PromiseStatus::Fulfilled(vec) => log!(
+        PromiseStatus::Fulfilled(Some(vec)) => log!(
             Level::Debug,
             "Success message: {}",
             String::from_bytes_vec(vec).unwrap()

--- a/wasm/test/demo-cli/src/main.rs
+++ b/wasm/test/demo-cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use seda_runtime_sdk::{
     wasm::{call_self, chain_call, chain_view, db_set, http_fetch, Promise},
     Chain,
+    FromBytes,
     PromiseStatus,
 };
 
@@ -81,7 +82,7 @@ fn http_fetch_result() {
     let result = Promise::result(0);
 
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_utf8(vec).unwrap(),
+        PromiseStatus::Fulfilled(Some(vec)) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
 
@@ -92,7 +93,7 @@ fn http_fetch_result() {
 fn chain_view_test_success() {
     let result = Promise::result(0);
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_utf8(vec).unwrap(),
+        PromiseStatus::Fulfilled(Some(vec)) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
     println!("Value: {value_to_store}");
@@ -104,7 +105,7 @@ fn chain_view_test_success() {
 fn chain_call_test_success() {
     let result = Promise::result(0);
     let value_to_store: String = match result {
-        PromiseStatus::Fulfilled(vec) => String::from_utf8(vec).unwrap(),
+        PromiseStatus::Fulfilled(Some(vec)) => String::from_bytes_vec(vec).unwrap(),
         _ => "Promise failed..".to_string(),
     };
     println!("Value: {value_to_store}");

--- a/wasm/test/promise-wasm-bin/src/main.rs
+++ b/wasm/test/promise-wasm-bin/src/main.rs
@@ -114,18 +114,7 @@ fn test_setting_execution_result_step1() {
 
 #[no_mangle]
 fn test_limited_runtime() {
-    db_set("foo", "bar")
-        .start()
-        .then(call_self("test_limited_runtime_rejected_db", vec![]));
-}
-
-#[no_mangle]
-fn test_limited_runtime_rejected_db() {
-    let result = Promise::result(0);
-    if let PromiseStatus::Rejected(rejected) = result {
-        let str = String::from_bytes(&rejected).unwrap();
-        println!("Promise rejected: {str}");
-    }
+    db_set("foo", "bar").start().then(call_self("test_rejected", vec![]));
 }
 
 #[no_mangle]
@@ -186,4 +175,20 @@ fn encode_hex(bytes: &[u8]) -> String {
     }
 
     result
+}
+
+#[no_mangle]
+fn test_error_turns_into_rejection() {
+    http_fetch("fail!").start().then(call_self("test_rejected", vec![]));
+}
+
+#[no_mangle]
+fn test_rejected() {
+    let result = Promise::result(0);
+    if let PromiseStatus::Rejected(rejected) = result {
+        let str = String::from_bytes(&rejected).unwrap();
+        println!("Promise rejected: {str}");
+    } else {
+        panic!("didn't reject");
+    }
 }

--- a/wasm/test/promise-wasm-bin/src/main.rs
+++ b/wasm/test/promise-wasm-bin/src/main.rs
@@ -17,7 +17,9 @@ use seda_runtime_sdk::{
         Promise,
         CONFIG,
     },
+    FromBytes,
     PromiseStatus,
+    ToBytes,
 };
 
 fn main() {
@@ -67,7 +69,7 @@ fn http_fetch_test_success() {
     let result = Promise::result(0);
 
     if let PromiseStatus::Fulfilled(bytes) = result {
-        let value_to_store = String::from_utf8(bytes).unwrap();
+        let value_to_store = String::from_bytes_vec(bytes).unwrap();
 
         db_set("http_fetch_result", &value_to_store).start();
     }
@@ -76,7 +78,7 @@ fn http_fetch_test_success() {
 #[no_mangle]
 fn memory_adapter_test_success() {
     let key = "u8";
-    let value = 234u8.to_le_bytes().to_vec();
+    let value = 234u8.to_bytes().eject();
     memory_write(key, value.clone());
 
     let read_value = memory_read(key);
@@ -84,7 +86,7 @@ fn memory_adapter_test_success() {
     assert_eq!(read_value, value);
 
     let key = "u32";
-    let value = 3467u32.to_le_bytes().to_vec();
+    let value = 3467u32.to_bytes().eject();
     memory_write(key, value);
     call_self("memory_adapter_callback_test_success", Vec::new()).start();
 }
@@ -106,7 +108,7 @@ fn test_setting_execution_result() {
 
 #[no_mangle]
 fn test_setting_execution_result_step1() {
-    let result = "test-success".to_string().into_bytes();
+    let result = "test-success".to_bytes().eject();
     execution_result(result);
 }
 

--- a/wasm/test/promise-wasm-bin/src/main.rs
+++ b/wasm/test/promise-wasm-bin/src/main.rs
@@ -138,12 +138,12 @@ fn bn254_verify_test() {
     // Signature
     let signature_hex = args.get(2).unwrap();
     let signature_bytes = decode_hex(signature_hex).unwrap();
-    let signature = Bn254Signature::from_compressed(&signature_bytes).unwrap();
+    let signature = Bn254Signature::from_compressed(signature_bytes).unwrap();
 
     // Public key
     let public_key_hex = args.get(3).unwrap();
     let public_key_bytes = decode_hex(public_key_hex).unwrap();
-    let public_key = Bn254PublicKey::from_compressed(&public_key_bytes).unwrap();
+    let public_key = Bn254PublicKey::from_compressed(public_key_bytes).unwrap();
 
     let result = bn254_verify(&message, &signature, &public_key);
     db_set("bn254_verify_result", &format!("{result}")).start();
@@ -165,7 +165,7 @@ fn bn254_sign_test() {
 
     let result = bn254_sign(&message, &private_key);
     let result_hex = encode_hex(&result.to_compressed().unwrap());
-    db_set("bn254_sign_result", &format!("{result_hex}")).start();
+    db_set("bn254_sign_result", &result_hex).start();
 }
 
 fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {

--- a/wasm/test/promise-wasm-bin/src/main.rs
+++ b/wasm/test/promise-wasm-bin/src/main.rs
@@ -68,7 +68,7 @@ fn http_fetch_test() {
 fn http_fetch_test_success() {
     let result = Promise::result(0);
 
-    if let PromiseStatus::Fulfilled(bytes) = result {
+    if let PromiseStatus::Fulfilled(Some(bytes)) = result {
         let value_to_store = String::from_bytes_vec(bytes).unwrap();
 
         db_set("http_fetch_result", &value_to_store).start();
@@ -123,7 +123,7 @@ fn test_limited_runtime() {
 fn test_limited_runtime_rejected_db() {
     let result = Promise::result(0);
     if let PromiseStatus::Rejected(rejected) = result {
-        let str = std::str::from_utf8(&rejected).unwrap();
+        let str = String::from_bytes(&rejected).unwrap();
         println!("Promise rejected: {str}");
     }
 }
@@ -170,6 +170,7 @@ fn bn254_sign_test() {
     db_set("bn254_sign_result", &result_hex).start();
 }
 
+// TODO: Something to include in our SDK? Or bn254 lib. Or use hex crate.
 fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
     (0..s.len())
         .step_by(2)
@@ -177,6 +178,7 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
         .collect()
 }
 
+// TODO: Something to include in our SDK? Or bn254 lib. Or use hex crate.
 fn encode_hex(bytes: &[u8]) -> String {
     let mut result = String::with_capacity(bytes.len() * 2);
     for &b in bytes {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So that errors within the runtime turn into promise rejections rather than halting the WASM execution.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Moved the `Bytes` type and its methods to the SDK(which also allowed some code cleanup in WASM files).
Then implemented, the `From` method for `Result<T: ToBytes, E: Error>` as well as  `Result<Option<T: ToBytes>, E: Error>`.

Most of the promise action handlers have now become one-liners.

The one exception is that `CallSelf` has not been updated to leverage this system.

That is because it has many more details and intricacies. Some of those errors mean we could not reject a promise because it means a runtime would fail to be started. While others would mean that we fail to capture `stdout`, `stderr`, etc. This code section would be better addressed in the PR that fixes that problem.

Finally, there's been a bunch of `TODO`s added in the SDK and other places. Much of this code can be cleaned up to make working with it easier(especially from the WASM side of things). However, in an effort to keep smaller PRs, these can be done in a Runtime clean-up PR.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Added a new test with an intentionally failing HTTP request to make sure that error turns into a promise rejection.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
-->

N/A
