### PR TITLE
feat(p2p): Add peer manager

### DIFF
--- a/config/src/configs/p2p.rs
+++ b/config/src/configs/p2p.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
@@ -10,15 +10,40 @@ use crate::{merge_config_cli, Config, Result};
 /// The configuration for the seda engine.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct PartialP2PConfig {
+    /// The amount of inbound peers we are trying to maintain
+    #[arg(long)]
+    pub in_peers:               Option<i32>,
+    /// The maximum amount of out peers we allow
+    #[arg(long)]
+    pub out_peers:              Option<i32>,
     /// An option to override the node p2p server address config value.
     #[arg(long)]
-    pub p2p_server_address: Option<String>,
+    pub p2p_server_address:     Option<String>,
     /// An option to override the node p2p known peers config value.
     #[arg(long)]
-    pub p2p_known_peers:    Option<Vec<String>>,
+    pub p2p_known_peers:        Option<Vec<String>>,
     /// Option to use mDNS to discover peers locally
     #[arg(long)]
-    pub enable_mdns:        Option<bool>,
+    pub disable_mdns:           Option<bool>,
+    /// Maximum amount of peers we want to use from mDNS
+    #[arg(long)]
+    pub max_mdns_peers:         Option<i32>,
+    /// Maximum amount of peers we want to use from our manually configured
+    /// peers
+    #[arg(long)]
+    pub max_manual_peers:       Option<i32>,
+    /// Option to disable usage of manually configured peers
+    #[arg(long)]
+    pub disable_manual_peers:   Option<bool>,
+    /// Maximum amount of peers we fetch from using Kademlia
+    #[arg(long)]
+    pub max_kademlia_peers:     Option<i32>,
+    /// Option to disable usage of kademlia
+    #[arg(long)]
+    pub disable_kademlia_peers: Option<bool>,
+    /// How long a peer should not be used due a connection issue in ms
+    #[arg(long)]
+    pub cooldown_duration:      Option<u64>,
 }
 
 #[cfg(feature = "cli")]
@@ -31,12 +56,45 @@ impl PartialP2PConfig {
             Ok(P2PConfigInner::P2P_SERVER_ADDRESS.to_string())
         )?;
         let p2p_known_peers = merge_config_cli!(self, cli_options, p2p_known_peers, Ok(Vec::new()))?;
-        let enable_mdns = merge_config_cli!(self, cli_options, enable_mdns, Ok(true))?;
+        let disable_mdns = merge_config_cli!(self, cli_options, disable_mdns, Ok(false))?;
+        let max_mdns_peers = merge_config_cli!(self, cli_options, max_mdns_peers, Ok(P2PConfigInner::MAX_MDNS_PEERS))?;
+        let in_peers = merge_config_cli!(self, cli_options, in_peers, Ok(P2PConfigInner::IN_PEERS))?;
+        let out_peers = merge_config_cli!(self, cli_options, out_peers, Ok(P2PConfigInner::OUT_PEERS))?;
+        let max_manual_peers = merge_config_cli!(
+            self,
+            cli_options,
+            max_manual_peers,
+            Ok(P2PConfigInner::MAX_MANUAL_PEERS)
+        )?;
+        let disable_manual_peers = merge_config_cli!(self, cli_options, disable_manual_peers, Ok(false))?;
+        let disable_kademlia_peers = merge_config_cli!(self, cli_options, disable_kademlia_peers, Ok(false))?;
+        let max_kademlia_peers = merge_config_cli!(
+            self,
+            cli_options,
+            max_kademlia_peers,
+            Ok(P2PConfigInner::MAX_KADEMLIA_PEERS)
+        )?;
+
+        let cooldown_duration = merge_config_cli!(
+            self,
+            cli_options,
+            cooldown_duration,
+            Ok(Duration::from_millis(P2PConfigInner::COOLDOWN_DURATION)),
+            Duration::from_millis
+        )?;
 
         Ok(Arc::new(P2PConfigInner {
             p2p_server_address,
             p2p_known_peers,
-            enable_mdns,
+            disable_mdns,
+            max_manual_peers,
+            max_mdns_peers,
+            disable_manual_peers,
+            in_peers,
+            out_peers,
+            disable_kademlia_peers,
+            max_kademlia_peers,
+            cooldown_duration,
         }))
     }
 }
@@ -45,9 +103,17 @@ impl PartialP2PConfig {
 impl Config for PartialP2PConfig {
     fn template() -> Self {
         Self {
-            p2p_server_address: Some(P2PConfigInner::P2P_SERVER_ADDRESS.to_string()),
-            p2p_known_peers:    None,
-            enable_mdns:        None,
+            p2p_server_address:     Some(P2PConfigInner::P2P_SERVER_ADDRESS.to_string()),
+            p2p_known_peers:        None,
+            disable_mdns:           None,
+            disable_manual_peers:   None,
+            max_manual_peers:       Some(P2PConfigInner::MAX_MANUAL_PEERS),
+            in_peers:               Some(P2PConfigInner::IN_PEERS),
+            out_peers:              Some(P2PConfigInner::OUT_PEERS),
+            max_mdns_peers:         Some(P2PConfigInner::MAX_MDNS_PEERS),
+            disable_kademlia_peers: None,
+            max_kademlia_peers:     Some(P2PConfigInner::MAX_KADEMLIA_PEERS),
+            cooldown_duration:      Some(P2PConfigInner::COOLDOWN_DURATION),
         }
     }
 
@@ -56,18 +122,34 @@ impl Config for PartialP2PConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct P2PConfigInner {
-    pub p2p_server_address: String,
-    pub p2p_known_peers:    Vec<String>,
-    pub enable_mdns:        bool,
+    pub p2p_server_address:     String,
+    pub p2p_known_peers:        Vec<String>,
+    pub disable_mdns:           bool,
+    pub max_mdns_peers:         i32,
+    pub in_peers:               i32,
+    pub out_peers:              i32,
+    pub disable_manual_peers:   bool,
+    pub max_manual_peers:       i32,
+    pub max_kademlia_peers:     i32,
+    pub disable_kademlia_peers: bool,
+    pub cooldown_duration:      Duration,
 }
 
 impl P2PConfigInner {
     // TODO cfg this
     pub fn test_config() -> P2PConfig {
         Arc::new(Self {
-            p2p_server_address: Self::P2P_SERVER_ADDRESS.to_string(),
-            p2p_known_peers:    Vec::new(),
-            enable_mdns:        true,
+            p2p_server_address:     Self::P2P_SERVER_ADDRESS.to_string(),
+            p2p_known_peers:        Vec::new(),
+            disable_mdns:           false,
+            disable_manual_peers:   false,
+            max_manual_peers:       Self::MAX_MANUAL_PEERS,
+            in_peers:               Self::IN_PEERS,
+            out_peers:              Self::OUT_PEERS,
+            max_mdns_peers:         Self::MAX_MDNS_PEERS,
+            disable_kademlia_peers: false,
+            max_kademlia_peers:     Self::MAX_KADEMLIA_PEERS,
+            cooldown_duration:      Duration::from_secs(Self::COOLDOWN_DURATION),
         })
     }
 
@@ -78,6 +160,13 @@ impl P2PConfigInner {
 }
 
 impl P2PConfigInner {
+    // 30 seconds
+    pub const COOLDOWN_DURATION: u64 = 30_000;
+    pub const IN_PEERS: i32 = 25;
+    pub const MAX_KADEMLIA_PEERS: i32 = 1000;
+    pub const MAX_MANUAL_PEERS: i32 = 1000;
+    pub const MAX_MDNS_PEERS: i32 = 1000;
+    pub const OUT_PEERS: i32 = 100;
     pub const P2P_SERVER_ADDRESS: &str = "/ip4/0.0.0.0/tcp/0";
 }
 

--- a/node/src/app/mod.rs
+++ b/node/src/app/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use actix::prelude::*;
 use parking_lot::RwLock;
 use seda_config::{ChainConfigs, NodeConfig};
-use seda_p2p::PeerList;
+use seda_p2p::DiscoveryStatus;
 use seda_runtime::HostAdapter;
 use seda_runtime_sdk::{events::EventId, p2p::P2PCommand};
 use tokio::sync::mpsc::Sender;
@@ -34,7 +34,7 @@ impl<HA: HostAdapter> App<HA> {
         rpc_server_address: &str,
         chain_configs: ChainConfigs,
         p2p_command_sender_channel: Sender<P2PCommand>,
-        known_peers: Arc<RwLock<PeerList>>,
+        disocvery_status: Arc<RwLock<DiscoveryStatus>>,
     ) -> Self {
         // Have to clone beforehand in order for the variable to be moved. (We also need
         // the same sender for the RPC)
@@ -51,7 +51,7 @@ impl<HA: HostAdapter> App<HA> {
             runtime_worker.clone(),
             rpc_server_address,
             p2p_command_sender_channel.clone(),
-            known_peers.clone(),
+            disocvery_status.clone(),
         )
         .await
         .expect("Error starting jsonrpsee server");

--- a/node/src/app/mod.rs
+++ b/node/src/app/mod.rs
@@ -34,7 +34,7 @@ impl<HA: HostAdapter> App<HA> {
         rpc_server_address: &str,
         chain_configs: ChainConfigs,
         p2p_command_sender_channel: Sender<P2PCommand>,
-        disocvery_status: Arc<RwLock<DiscoveryStatus>>,
+        disocvery_status: DiscoveryStatus,
     ) -> Self {
         // Have to clone beforehand in order for the variable to be moved. (We also need
         // the same sender for the RPC)

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) use host::*;
 pub use host::{ChainCall, ChainView};
 use parking_lot::RwLock;
 use seda_config::{ChainConfigs, NodeConfig, P2PConfig};
-use seda_p2p::{libp2p::P2PServer, DiscoveryStatus, PeerList};
+use seda_p2p::{libp2p::P2PServer, DiscoveryStatusInner, PeerList};
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 use tokio::sync::mpsc::channel;
 use tracing::info;
@@ -37,7 +37,7 @@ pub fn run(seda_server_address: &str, config: NodeConfig, p2p_config: P2PConfig,
         let (p2p_command_sender, p2p_command_receiver) = channel::<P2PCommand>(100);
 
         let known_peers = PeerList::from_vec(&p2p_config.p2p_known_peers);
-        let discovery_status = Arc::new(RwLock::new(DiscoveryStatus::new(p2p_config.clone(), known_peers)));
+        let discovery_status = Arc::new(RwLock::new(DiscoveryStatusInner::new(p2p_config.clone(), known_peers)));
 
         // TODO: add number of workers as config with default value
         let app = App::<RuntimeAdapter>::new(

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) use host::*;
 pub use host::{ChainCall, ChainView};
 use parking_lot::RwLock;
 use seda_config::{ChainConfigs, NodeConfig, P2PConfig};
-use seda_p2p::{libp2p::P2PServer, PeerList};
+use seda_p2p::{libp2p::P2PServer, DiscoveryStatus, PeerList};
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 use tokio::sync::mpsc::channel;
 use tracing::info;
@@ -36,7 +36,8 @@ pub fn run(seda_server_address: &str, config: NodeConfig, p2p_config: P2PConfig,
         let (p2p_message_sender, p2p_message_receiver) = channel::<P2PMessage>(100);
         let (p2p_command_sender, p2p_command_receiver) = channel::<P2PCommand>(100);
 
-        let known_peers = Arc::new(RwLock::new(PeerList::from_vec(&p2p_config.p2p_known_peers)));
+        let known_peers = PeerList::from_vec(&p2p_config.p2p_known_peers);
+        let discovery_status = Arc::new(RwLock::new(DiscoveryStatus::new(p2p_config.clone(), known_peers)));
 
         // TODO: add number of workers as config with default value
         let app = App::<RuntimeAdapter>::new(
@@ -44,26 +45,24 @@ pub fn run(seda_server_address: &str, config: NodeConfig, p2p_config: P2PConfig,
             seda_server_address,
             chain_configs,
             p2p_command_sender,
-            known_peers.clone(),
+            discovery_status.clone(),
         )
         .await
         .start();
 
-        // TODO: Use config for P2P Server
-        let mut p2p_server = P2PServer::start_from_config(
+        let mut p2p_server = P2PServer::new(
+            discovery_status.clone(),
             p2p_config.clone(),
-            known_peers,
             p2p_message_sender,
             p2p_command_receiver,
         )
         .await
         .expect("P2P swarm cannot be started");
 
-        p2p_server.dial_peers().await.expect("P2P dial behaviour failed");
-
         // P2P initialization
         // TODO: most probably this process should be moved somewhere else
         actix::spawn(async move {
+            p2p_server.start().await;
             p2p_server.loop_stream().await.expect("P2P Loop failed");
         });
 

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use actix::prelude::*;
 use jsonrpsee::{
@@ -6,7 +6,6 @@ use jsonrpsee::{
     proc_macros::rpc,
     server::{ServerBuilder, ServerHandle},
 };
-use parking_lot::RwLock;
 use seda_p2p::{
     libp2p::{Multiaddr, PeerId},
     DiscoveryStatus,
@@ -43,7 +42,7 @@ pub trait Rpc {
 pub struct CliServer<HA: HostAdapter> {
     runtime_worker:             Addr<RuntimeWorker<HA>>,
     p2p_command_sender_channel: Sender<P2PCommand>,
-    discovery_status:           Arc<RwLock<DiscoveryStatus>>,
+    discovery_status:           DiscoveryStatus,
 }
 
 #[async_trait]
@@ -117,7 +116,7 @@ impl JsonRpcServer {
         runtime_worker: Addr<RuntimeWorker<HA>>,
         addrs: &str,
         p2p_command_sender_channel: Sender<P2PCommand>,
-        discovery_status: Arc<RwLock<DiscoveryStatus>>,
+        discovery_status: DiscoveryStatus,
     ) -> Result<Self, Error> {
         let server = ServerBuilder::default().build(addrs).await?;
         let rpc = CliServer {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -3,4 +3,4 @@ pub use errors::*;
 
 pub mod libp2p;
 
-pub use crate::libp2p::peer_list::PeerList;
+pub use crate::libp2p::{discovery_status::DiscoveryStatus, peer_list::PeerList};

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -3,4 +3,7 @@ pub use errors::*;
 
 pub mod libp2p;
 
-pub use crate::libp2p::{discovery_status::DiscoveryStatus, peer_list::PeerList};
+pub use crate::libp2p::{
+    discovery_status::{DiscoveryStatus, DiscoveryStatusInner},
+    peer_list::PeerList,
+};

--- a/p2p/src/libp2p/behaviour.rs
+++ b/p2p/src/libp2p/behaviour.rs
@@ -61,6 +61,8 @@ impl SedaBehaviour {
         let local_peer_id = PeerId::from(key_pair.public());
         let mut kademlia_config = KademliaConfig::default();
         kademlia_config.disjoint_query_paths(true);
+        kademlia_config.set_kbucket_inserts(libp2p::kad::KademliaBucketInserts::Manual);
+
         let kademlia_memory_store = MemoryStore::new(local_peer_id);
         let kademlia = Kademlia::with_config(local_peer_id, kademlia_memory_store, kademlia_config);
 

--- a/p2p/src/libp2p/discovery_status.rs
+++ b/p2p/src/libp2p/discovery_status.rs
@@ -1,0 +1,219 @@
+use std::{collections::HashMap, ops::Add, time::SystemTime};
+
+use libp2p::{Multiaddr, PeerId};
+use seda_config::P2PConfig;
+
+use super::peer_list::{ConnectionType, PeerInfo};
+use crate::PeerList;
+
+/// The manager should use this
+/// The manager should not check the config but just have a switch statement
+/// This struct will check all connections and config which discovery method
+/// should be used
+
+pub struct DiscoveryStatus {
+    p2p_config: P2PConfig,
+
+    pub connected_peers: PeerList,
+
+    /// Peers who should not be connected to until the cooldown period has ended
+    /// This prevents the manager to try to connect to the same failing peer
+    cooldown_addrs: HashMap<Multiaddr, SystemTime>,
+
+    // Peers that have been found by a discovery mechanism
+    // but don't have to be connected, we can use this if we want to add them
+    found_manual_peers:   PeerList,
+    found_chain_peers:    PeerList,
+    found_mdns_peers:     PeerList,
+    found_kademlia_peers: PeerList,
+}
+
+impl DiscoveryStatus {
+    pub fn new(p2p_config: P2PConfig, inital_manual_peers: PeerList) -> Self {
+        Self {
+            p2p_config,
+            found_manual_peers: inital_manual_peers,
+            found_chain_peers: PeerList::default(),
+            found_mdns_peers: PeerList::default(),
+            found_kademlia_peers: PeerList::default(),
+            connected_peers: PeerList::default(),
+            cooldown_addrs: HashMap::default(),
+        }
+    }
+
+    fn get_connected_len_by_type(&self, connection_type: ConnectionType) -> i32 {
+        let mut len: i32 = 0;
+
+        for (_addr, info) in self.connected_peers.get_all_info().iter() {
+            if info.conn_type == connection_type {
+                len += 1;
+            }
+        }
+
+        len
+    }
+
+    pub fn get_connected_list(&self) -> PeerList {
+        println!("Kademlia: {:?}", self.found_kademlia_peers);
+        println!("mDNS: {:?}", self.found_mdns_peers);
+
+        self.connected_peers.clone()
+    }
+
+    /// Checks if the peer is already connected to and hasn't been tried
+    /// recently
+    fn is_unused_addr(&mut self, addr: &Multiaddr) -> bool {
+        if self.connected_peers.has_addr(addr) {
+            return false;
+        }
+
+        if let Some(peer_cooldowned_time) = self.cooldown_addrs.get(addr) {
+            let now = SystemTime::now();
+
+            println!("Peer {addr} still in cooldown");
+
+            // When the cooldown period has exceeded
+            if now > peer_cooldowned_time.add(self.p2p_config.cooldown_duration) {
+                println!("Release peer {addr} from cooldown");
+                self.cooldown_addrs.remove(addr);
+                return true;
+            }
+
+            return false;
+        }
+
+        true
+    }
+
+    /// Gets the discovery method the manager should use
+    /// Based on priority and maximum allowed peers from that specific discovery
+    /// method
+    /// * `skip` - Allows to skip any higher priorty then the one given (if for
+    ///   example we already exhausted that source)
+    pub fn get_current_discovery_method(&self, skip: Option<ConnectionType>) -> ConnectionType {
+        // We already reached the maximum required peers, we don't need more
+        if self.connected_peers.len() as i32 >= self.p2p_config.out_peers {
+            return ConnectionType::None;
+        }
+
+        let skip = skip.unwrap_or(ConnectionType::None);
+
+        if !self.p2p_config.disable_manual_peers
+            && self.get_connected_len_by_type(ConnectionType::Manual) < self.p2p_config.max_manual_peers
+            && skip < ConnectionType::Manual
+        {
+            return ConnectionType::Manual;
+        }
+
+        if !self.p2p_config.disable_mdns
+            && self.get_connected_len_by_type(ConnectionType::MDns) < self.p2p_config.max_mdns_peers
+            && skip < ConnectionType::MDns
+        {
+            return ConnectionType::MDns;
+        }
+
+        if !self.p2p_config.disable_kademlia_peers
+            && self.get_connected_len_by_type(ConnectionType::Kademlia) < self.p2p_config.max_kademlia_peers
+            && skip < ConnectionType::Kademlia
+        {
+            return ConnectionType::Kademlia;
+        }
+
+        ConnectionType::None
+    }
+
+    pub fn cooldown_addr(&mut self, addr: Multiaddr) {
+        println!("Added {addr} to cooldown");
+        self.cooldown_addrs.insert(addr, SystemTime::now());
+    }
+
+    pub fn add_connected_peer(&mut self, addr: Multiaddr, peer_id: PeerId) {
+        self.connected_peers.set_peer_id(addr, peer_id);
+    }
+
+    pub fn remove_connected_peer(&mut self, peer_id: Option<&PeerId>, address: Option<&Multiaddr>) {
+        if let Some(peer_id) = peer_id {
+            if let Some((_addr, peer_info)) = self.connected_peers.get_peer_by_id(peer_id) {
+                match peer_info.conn_type {
+                    ConnectionType::Chain => self.found_chain_peers.remove_peer_by_id(peer_id),
+                    ConnectionType::Kademlia => self.found_kademlia_peers.remove_peer_by_id(peer_id),
+                    ConnectionType::MDns => self.found_mdns_peers.remove_peer_by_id(peer_id),
+                    // Manual peers (and none) should not remove anything
+                    // We are expecting them to maybe be available again
+                    _ => {}
+                }
+            }
+
+            self.connected_peers.remove_peer_by_id(peer_id);
+        }
+
+        if let Some(addr) = address {
+            if let Some(peer_info) = self.connected_peers.get_peer_by_addr(addr) {
+                match peer_info.conn_type {
+                    ConnectionType::Chain => self.found_chain_peers.remove_peer_by_addr(addr),
+                    ConnectionType::Kademlia => self.found_kademlia_peers.remove_peer_by_addr(addr),
+                    ConnectionType::MDns => self.found_mdns_peers.remove_peer_by_addr(addr),
+                    // Manual peers (and none) should not remove anything
+                    // We are expecting them to maybe be available again
+                    _ => {}
+                }
+            }
+
+            self.connected_peers.remove_peer_by_addr(addr);
+        }
+    }
+
+    pub fn get_next_manual_peer(&mut self) -> Option<(Multiaddr, PeerInfo)> {
+        for (addr, peer_info) in self.found_manual_peers.get_all_info().iter() {
+            if self.is_unused_addr(addr) {
+                self.connected_peers
+                    .add_peer(addr.clone(), peer_info.peer_id, ConnectionType::Manual);
+
+                return Some((addr.clone(), peer_info.clone()));
+            }
+        }
+
+        None
+    }
+
+    pub fn add_mdns_peer(&mut self, addr: Multiaddr, peer_id: PeerId) {
+        self.found_mdns_peers
+            .add_peer(addr, Some(peer_id), ConnectionType::MDns);
+    }
+
+    pub fn get_next_mdns_peer(&mut self) -> Option<(Multiaddr, PeerInfo)> {
+        for (addr, peer_info) in self.found_mdns_peers.get_all_info().iter() {
+            if self.is_unused_addr(addr) {
+                self.connected_peers
+                    .add_peer(addr.clone(), peer_info.peer_id, ConnectionType::MDns);
+
+                return Some((addr.clone(), peer_info.clone()));
+            }
+        }
+
+        None
+    }
+
+    pub fn add_kademlia_peer(&mut self, addr: Multiaddr, peer_id: PeerId) {
+        self.found_kademlia_peers
+            .add_peer(addr, Some(peer_id), ConnectionType::Kademlia);
+    }
+
+    pub fn get_next_kademlia_peer(&mut self) -> Option<(Multiaddr, PeerInfo)> {
+        for (addr, peer_info) in self.found_kademlia_peers.get_all_info().iter() {
+            if self.is_unused_addr(addr) {
+                self.connected_peers
+                    .add_peer(addr.clone(), peer_info.peer_id, ConnectionType::Kademlia);
+
+                return Some((addr.clone(), peer_info.clone()));
+            }
+        }
+
+        None
+    }
+
+    pub fn add_manual_peer(&mut self, addr: Multiaddr, peer_id: Option<PeerId>) {
+        self.found_kademlia_peers
+            .add_peer(addr, peer_id, ConnectionType::Kademlia);
+    }
+}

--- a/p2p/src/libp2p/libp2p_test.rs
+++ b/p2p/src/libp2p/libp2p_test.rs
@@ -7,7 +7,7 @@ use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 use tokio::sync::mpsc::channel;
 
 use super::P2PServer;
-use crate::libp2p::peer_list::PeerList;
+use crate::{libp2p::peer_list::PeerList, DiscoveryStatus};
 
 #[tokio::test]
 async fn p2p_service_works() {
@@ -15,10 +15,13 @@ async fn p2p_service_works() {
     let (_p2p_command_sender, p2p_command_receiver) = channel::<P2PCommand>(100);
 
     let p2p_config = P2PConfigInner::test_config();
-    let known_peers = Arc::new(RwLock::new(PeerList::from_vec(&p2p_config.p2p_known_peers)));
-    let mut p2p_service = P2PServer::start_from_config(
+    let discovery_status = Arc::new(RwLock::new(DiscoveryStatus::new(
         p2p_config.clone(),
-        known_peers,
+        PeerList::from_vec(&p2p_config.p2p_known_peers),
+    )));
+    let mut p2p_service = P2PServer::new(
+        discovery_status,
+        p2p_config.clone(),
         p2p_message_sender,
         p2p_command_receiver,
     )

--- a/p2p/src/libp2p/libp2p_test.rs
+++ b/p2p/src/libp2p/libp2p_test.rs
@@ -7,7 +7,7 @@ use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
 use tokio::sync::mpsc::channel;
 
 use super::P2PServer;
-use crate::{libp2p::peer_list::PeerList, DiscoveryStatus};
+use crate::{libp2p::peer_list::PeerList, DiscoveryStatusInner};
 
 #[tokio::test]
 async fn p2p_service_works() {
@@ -15,7 +15,7 @@ async fn p2p_service_works() {
     let (_p2p_command_sender, p2p_command_receiver) = channel::<P2PCommand>(100);
 
     let p2p_config = P2PConfigInner::test_config();
-    let discovery_status = Arc::new(RwLock::new(DiscoveryStatus::new(
+    let discovery_status = Arc::new(RwLock::new(DiscoveryStatusInner::new(
         p2p_config.clone(),
         PeerList::from_vec(&p2p_config.p2p_known_peers),
     )));

--- a/p2p/src/libp2p/mod.rs
+++ b/p2p/src/libp2p/mod.rs
@@ -2,12 +2,14 @@ mod behaviour;
 pub mod peer_list;
 mod transport;
 
+pub mod discovery_status;
 #[cfg(test)]
 mod libp2p_test;
 
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc, time::Duration};
 
-use async_std::io::{self, prelude::BufReadExt};
+use behaviour::SedaBehaviour;
+use discovery_status::DiscoveryStatus;
 use libp2p::{
     core::ConnectedPoint,
     futures::StreamExt,
@@ -15,35 +17,38 @@ use libp2p::{
     identity::{self},
     kad::{KademliaEvent, QueryResult},
     mdns::Event as MdnsEvent,
-    swarm::{Swarm, SwarmEvent},
+    swarm::{DialError, NetworkBehaviour, SwarmEvent},
+    Swarm,
 };
 pub use libp2p::{Multiaddr, PeerId};
 use parking_lot::RwLock;
+use peer_list::{ConnectionType, PeerInfo};
 use seda_config::P2PConfig;
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
-use tokio::sync::mpsc::{Receiver, Sender};
-
-use self::{behaviour::SedaBehaviour, peer_list::PeerList};
-use crate::{
-    errors::Result,
-    libp2p::{behaviour::SedaBehaviourEvent, transport::build_tcp_transport},
+use tokio::{
+    sync::mpsc::{Receiver, Sender},
+    time,
 };
+use transport::build_tcp_transport;
+
+use crate::{libp2p::behaviour::SedaBehaviourEvent, Result};
 
 pub const GOSSIP_TOPIC: &str = "testnet";
+pub const SEARCH_PEER_INTERVAL: u64 = 10_000;
 
 pub struct P2PServer {
-    pub p2p_config:               P2PConfig,
-    pub known_peers:              Arc<RwLock<PeerList>>,
-    pub local_key:                identity::Keypair,
-    pub swarm:                    Swarm<SedaBehaviour>,
-    pub message_sender_channel:   Sender<P2PMessage>,
-    pub command_receiver_channel: Receiver<P2PCommand>,
+    swarm:            Swarm<SedaBehaviour>,
+    discovery_status: Arc<RwLock<DiscoveryStatus>>,
+    local_peer_id:    PeerId,
+
+    message_sender_channel:   Sender<P2PMessage>,
+    command_receiver_channel: Receiver<P2PCommand>,
 }
 
 impl P2PServer {
-    pub async fn start_from_config(
+    pub async fn new(
+        discovery_status: Arc<RwLock<DiscoveryStatus>>,
         p2p_config: P2PConfig,
-        known_peers: Arc<RwLock<PeerList>>,
         message_sender_channel: Sender<P2PMessage>,
         command_receiver_channel: Receiver<P2PCommand>,
     ) -> Result<Self> {
@@ -53,126 +58,150 @@ impl P2PServer {
         let local_peer_id = PeerId::from(local_key.public());
         tracing::info!("Local peer id: {:?}", local_peer_id);
 
-        // Create transport and behaviour
         let transport = build_tcp_transport(local_key.clone())?;
         let seda_behaviour = SedaBehaviour::new(&local_key).await?;
+        let mut swarm = Swarm::with_threadpool_executor(transport, seda_behaviour, local_peer_id);
 
-        let mut swarm = Swarm::with_threadpool_executor(transport, seda_behaviour, PeerId::from(local_key.public()));
         swarm.listen_on(p2p_config.p2p_server_address.parse()?)?;
 
         Ok(Self {
-            p2p_config,
-            known_peers,
-            local_key,
+            local_peer_id,
             swarm,
-            message_sender_channel,
+            discovery_status,
             command_receiver_channel,
+            message_sender_channel,
         })
     }
 
-    pub async fn dial_peers(&mut self) -> Result<()> {
-        let known_peers = self.known_peers.read();
-
-        known_peers.get_all().iter().for_each(|(peer_addr, _peer_id)| {
-            match self.swarm.dial(*peer_addr) {
-                Ok(_) => {
-                    tracing::debug!("Dialed {}", peer_addr);
-                }
-                Err(error) => tracing::warn!("Couldn't dial peer ({}): {:?}", peer_addr, error),
-            };
-        });
-
-        Ok(())
+    pub async fn start(&mut self) {
+        self.search_new_peer(None);
     }
 
-    /// Dials the peer and adds it to our known peers list
-    fn dial_peer(&mut self, peer_addr: &String) {
-        let mut known_peers = self.known_peers.write();
+    /// Searches for new peers,
+    /// goes through all the behaviours and tries to find a new peer
+    /// This only tries to find one peer at a time
+    pub fn search_new_peer(&mut self, skip: Option<ConnectionType>) {
+        let current_discovery_method: ConnectionType = {
+            let discovery_status = self.discovery_status.read();
+            discovery_status.get_current_discovery_method(skip)
+        };
 
-        if let Ok(peer_multi_addr) = peer_addr.parse::<Multiaddr>() {
-            match self.swarm.dial(peer_multi_addr.clone()) {
-                Ok(_) => {
-                    tracing::debug!("Dialed {}", peer_addr);
-                    known_peers.add_peer(peer_multi_addr, None);
-                }
-                Err(error) => tracing::warn!("Couldn't dial peer ({}): {:?}", peer_addr, error),
+        match current_discovery_method {
+            ConnectionType::Manual => self.search_manual_peers(),
+            ConnectionType::MDns => self.search_mdns_peers(),
+            ConnectionType::Chain => {
+                // TODO: Add chain peers
+                self.search_new_peer(Some(ConnectionType::Chain));
             }
-        } else {
-            tracing::warn!("Couldn't dial peer with address: {}", peer_addr);
+            ConnectionType::Kademlia => self.search_kademlia_peers(),
+            ConnectionType::None => {
+                tracing::debug!("No new peers found");
+            }
         }
     }
 
-    fn add_peer(&mut self, addr: Multiaddr, peer_id: PeerId) {
-        let mut known_peers = self.known_peers.write();
-        known_peers.add_peer(addr.clone(), Some(peer_id));
-
-        self.swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
-
-        self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
+    fn dial_peer(&mut self, addr: Multiaddr) {
+        if let Err(error) = self.swarm.dial(addr.clone()) {
+            tracing::warn!("Couldn't dial peer ({}): {:?}", &addr, error);
+        }
     }
 
-    fn remove_peer(&mut self, peer_id: PeerId) {
-        let mut known_peers = self.known_peers.write();
-        known_peers.remove_peer_by_id(peer_id);
+    fn search_manual_peers(&mut self) {
+        let next_manual_peer: Option<(Multiaddr, PeerInfo)> = {
+            let mut discovery_status = self.discovery_status.write();
+            discovery_status.get_next_manual_peer()
+        };
 
-        if self.swarm.disconnect_peer_id(peer_id).is_ok() {
-            tracing::debug!("Removed peer {peer_id}");
+        if let Some((addr, _peer_info)) = next_manual_peer {
+            self.dial_peer(addr);
+        } else {
+            self.search_new_peer(Some(ConnectionType::Manual));
+        }
+    }
+
+    fn search_mdns_peers(&mut self) {
+        let next_mdns_peer: Option<(Multiaddr, PeerInfo)> = {
+            let mut discovery_status = self.discovery_status.write();
+            discovery_status.get_next_mdns_peer()
+        };
+
+        if let Some((addr, _peer_info)) = next_mdns_peer {
+            self.dial_peer(addr);
+        } else {
+            self.search_new_peer(Some(ConnectionType::MDns));
+        }
+    }
+
+    fn search_kademlia_peers(&mut self) {
+        let next_kademlia_peer: Option<(Multiaddr, PeerInfo)> = {
+            let mut discovery_status = self.discovery_status.write();
+            discovery_status.get_next_kademlia_peer()
+        };
+
+        if let Some((addr, _peer_info)) = next_kademlia_peer {
+            self.dial_peer(addr);
+        } else {
+            self.swarm
+                .behaviour_mut()
+                .kademlia
+                .get_closest_peers(self.local_peer_id);
         }
     }
 
     pub async fn loop_stream(&mut self) -> Result<()> {
-        // TODO: Remove stdin feature
-        let mut stdin = io::BufReader::new(io::stdin()).lines().fuse();
         let topic = IdentTopic::new(GOSSIP_TOPIC);
-
-        self.swarm.behaviour_mut().kademlia.get_closest_peers(PeerId::random());
+        let mut search_peers_interval = time::interval(Duration::from_millis(SEARCH_PEER_INTERVAL));
 
         loop {
             tokio::select! {
-                // TODO: Remove stdin feature after we got a working p2p message system
-                line = stdin.select_next_some() => {
-                    if let Err(e) = self.swarm
-                        .behaviour_mut().gossipsub
-                        .publish(topic.clone(), line.expect("Stdin not to close").as_bytes()) {
-                        tracing::error!("Publish error: {e:?}");
-                    }
+                _ = search_peers_interval.tick() => {
+                    self.search_new_peer(None);
                 },
+
                 event = self.swarm.select_next_some() => match event {
+                    // Swarm
                     SwarmEvent::NewListenAddr { address, .. } => tracing::info!("Listening on {:?}", address),
-                    SwarmEvent::Behaviour(SedaBehaviourEvent::Mdns(MdnsEvent::Discovered(list))) => {
-                        if !self.p2p_config.enable_mdns {
-                            continue;
-                        }
-
-                        for (peer_id, multiaddr) in list {
-                            tracing::debug!("mDNS discovered a new peer: {}", peer_id);
-                            self.add_peer(multiaddr, peer_id);
-                        }
-                    }
-                    SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
-                        let mut known_peers = self.known_peers.write();
-
+                    SwarmEvent::ConnectionEstablished { peer_id, endpoint: ConnectedPoint::Dialer { address, .. }, .. } => {
                         tracing::debug!("Connection established with {peer_id}");
 
-                        if let ConnectedPoint::Dialer { address, .. } = endpoint {
-                            self.swarm
-                                .behaviour_mut()
-                                .kademlia
-                                .add_address(&peer_id, address.clone());
-
-                            known_peers.set_peer_id(address, peer_id)
-                        }
-                    }
-                    SwarmEvent::Behaviour(SedaBehaviourEvent::Mdns(MdnsEvent::Expired(list))) => {
-                        if !self.p2p_config.enable_mdns {
-                            continue;
+                        {
+                            let mut discovery_status = self.discovery_status.write();
+                            discovery_status.add_connected_peer(address.clone(), peer_id);
                         }
 
-                        for (peer_id, _multiaddr) in list {
-                            tracing::debug!("mDNS discover peer has expired: {}", peer_id);
-                            self.remove_peer(peer_id);
+                        self.swarm.behaviour_mut().kademlia.add_address(&peer_id, address);
+                        self.swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
+                        self.search_new_peer(None);
+                    },
+
+                    SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                        tracing::debug!("Connection closed with {peer_id}");
+
+                        {
+                            let mut discovery_status = self.discovery_status.write();
+                            discovery_status.remove_connected_peer(Some(&peer_id), None);
                         }
-                    }
+
+                        self.search_new_peer(None);
+                        self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
+                    },
+
+                    SwarmEvent::OutgoingConnectionError { peer_id: _, error } => {
+                        {
+                            let mut discovery_status = self.discovery_status.write();
+
+                            if let DialError::Transport(failed_peers) = error {
+                                for (addr, _transport_error) in failed_peers {
+                                    discovery_status.remove_connected_peer(None, Some(&addr));
+                                    discovery_status.cooldown_addr(addr);
+                                }
+                            }
+                        }
+
+                        self.search_new_peer(None);
+                    },
+
+                    // Gossip
                     SwarmEvent::Behaviour(SedaBehaviourEvent::Gossipsub(GossipsubEvent::Message {
                         propagation_source: peer_id,
                         message_id: id,
@@ -189,24 +218,49 @@ impl P2PServer {
                             tracing::error!("Couldn't send message through channel: {err}");
                         }
                     },
+
+                    // mDNS behaviour
+                    SwarmEvent::Behaviour(SedaBehaviourEvent::Mdns(MdnsEvent::Discovered(list))) => {
+                        {
+                            let mut discovery_status = self.discovery_status.write();
+
+                            for (peer_id, addr) in list {
+                                discovery_status.add_mdns_peer(addr, peer_id);
+                            }
+                        }
+
+                        self.search_new_peer(None);
+                    },
+
+                    // Kademlia behaviour
                     SwarmEvent::Behaviour(SedaBehaviourEvent::Kademlia(KademliaEvent::OutboundQueryProgressed {
                         result: QueryResult::GetClosestPeers(result),
                         ..
                     })) => {
                         match result {
                             Ok(closest_peers_query_result) => {
-                                if closest_peers_query_result.peers.is_empty() {
-                                    tracing::debug!("No new peers found using kademlia");
+                                if !closest_peers_query_result.peers.is_empty() {
+                                    let mut discovery_status = self.discovery_status.write();
+
+                                    for peer_id in closest_peers_query_result.peers {
+                                        let addresses = self.swarm.behaviour_mut().kademlia.addresses_of_peer(&peer_id);
+
+                                        if let Some(first_address) = addresses.first() {
+                                            discovery_status.add_kademlia_peer(first_address.clone(), peer_id);
+                                        }
+                                    }
                                 } else {
-                                    tracing::debug!("Found new peers: {:#?}", closest_peers_query_result.peers);
+                                    tracing::debug!("Kademlia couldn't find new peers");
                                 }
                             }
                             Err(err) => tracing::error!("Error while using Kademlia: {err}")
                         }
-                    }
+                    },
                     _ => {}
                 },
+
                 task = self.command_receiver_channel.recv() => match task {
+                    None => {},
                     Some(P2PCommand::Broadcast(data)) => {
                         if let Err(e) = self.swarm.behaviour_mut().gossipsub.publish(topic.clone(), data) {
                             tracing::error!("Publish error: {e:?}");
@@ -216,24 +270,36 @@ impl P2PServer {
                         unimplemented!("Todo unicast");
                     },
                     Some(P2PCommand::AddPeer(add_peer_command)) => {
-                        self.dial_peer(&add_peer_command.multi_addr);
+                        if let Ok(multi_addr) = add_peer_command.multi_addr.parse::<Multiaddr>() {
+                            {
+                                let mut discovery_status = self.discovery_status.write();
+                                discovery_status.add_manual_peer(multi_addr, None);
+                            }
+
+                            self.search_new_peer(None);
+                        } else {
+                            tracing::warn!("Couldn't add peer, invalid address: {}", add_peer_command.multi_addr);
+                        }
                     },
                     Some(P2PCommand::RemovePeer(remove_peer_command)) => {
                         match PeerId::from_str(&remove_peer_command.peer_id) {
-                            Ok(peer_id) => self.remove_peer(peer_id),
-                            Err(error) => tracing::error!("PeerId {} is invalid due: {error}", &remove_peer_command.peer_id),
+                            Ok(peer_id) => {
+                                self.swarm.disconnect_peer_id(peer_id).ok();
+
+                                {
+                                    let mut discovery_status = self.discovery_status.write();
+                                    discovery_status.remove_connected_peer(Some(&peer_id), None);
+                                }
+
+                                self.search_new_peer(None);
+                            },
+                            Err(error) => tracing::warn!("PeerId {} is invalid: {error}", &remove_peer_command.peer_id)
                         }
                     },
                     Some(P2PCommand::DiscoverPeers) => {
-                        let local_peer_id = PeerId::from(self.local_key.public());
-
-                        self.swarm
-                            .behaviour_mut()
-                            .kademlia
-                            .get_closest_peers(local_peer_id);
-                    },
-                    None => {}
-                },
+                        self.search_new_peer(None);
+                    }
+                }
             }
         }
     }

--- a/p2p/src/libp2p/mod.rs
+++ b/p2p/src/libp2p/mod.rs
@@ -6,7 +6,7 @@ pub mod discovery_status;
 #[cfg(test)]
 mod libp2p_test;
 
-use std::{str::FromStr, sync::Arc, time::Duration};
+use std::{str::FromStr, time::Duration};
 
 use behaviour::SedaBehaviour;
 use discovery_status::DiscoveryStatus;
@@ -21,7 +21,6 @@ use libp2p::{
     Swarm,
 };
 pub use libp2p::{Multiaddr, PeerId};
-use parking_lot::RwLock;
 use peer_list::{ConnectionType, PeerInfo};
 use seda_config::P2PConfig;
 use seda_runtime_sdk::p2p::{P2PCommand, P2PMessage};
@@ -38,7 +37,7 @@ pub const SEARCH_PEER_INTERVAL: u64 = 10_000;
 
 pub struct P2PServer {
     swarm:            Swarm<SedaBehaviour>,
-    discovery_status: Arc<RwLock<DiscoveryStatus>>,
+    discovery_status: DiscoveryStatus,
     local_peer_id:    PeerId,
 
     message_sender_channel:   Sender<P2PMessage>,
@@ -47,7 +46,7 @@ pub struct P2PServer {
 
 impl P2PServer {
     pub async fn new(
-        discovery_status: Arc<RwLock<DiscoveryStatus>>,
+        discovery_status: DiscoveryStatus,
         p2p_config: P2PConfig,
         message_sender_channel: Sender<P2PMessage>,
         command_receiver_channel: Receiver<P2PCommand>,
@@ -95,7 +94,7 @@ impl P2PServer {
             }
             ConnectionType::Kademlia => self.search_kademlia_peers(),
             ConnectionType::None => {
-                tracing::debug!("No new peers found");
+                tracing::debug!("No new peers found/needed");
             }
         }
     }

--- a/p2p/src/libp2p/peer_list.rs
+++ b/p2p/src/libp2p/peer_list.rs
@@ -3,8 +3,24 @@ use std::{collections::HashMap, str::FromStr};
 use libp2p::{Multiaddr, PeerId};
 use serde_json::Value;
 
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq)]
+pub enum ConnectionType {
+    None     = -1,
+    Manual   = 0,
+    MDns     = 1,
+    Chain    = 2,
+    Kademlia = 3,
+}
+
+#[derive(Clone, Debug)]
+pub struct PeerInfo {
+    pub peer_id:   Option<PeerId>,
+    pub conn_type: ConnectionType,
+}
+
+#[derive(Default, Debug, Clone)]
 pub struct PeerList {
-    addr_to_peer: HashMap<Multiaddr, Option<PeerId>>,
+    addr_to_peer: HashMap<Multiaddr, PeerInfo>,
     peer_to_addr: HashMap<PeerId, Multiaddr>,
 }
 
@@ -13,7 +29,13 @@ impl PeerList {
         let mut addr_to_peer = HashMap::new();
 
         unparsed_multi_addresses.iter().for_each(|unparsed_addr| {
-            addr_to_peer.insert(Multiaddr::from_str(unparsed_addr).unwrap(), None);
+            addr_to_peer.insert(
+                Multiaddr::from_str(unparsed_addr).unwrap(),
+                PeerInfo {
+                    peer_id:   None,
+                    conn_type: ConnectionType::Manual,
+                },
+            );
         });
 
         PeerList {
@@ -22,37 +44,77 @@ impl PeerList {
         }
     }
 
-    pub fn add_peer(&mut self, multi_addr: Multiaddr, peer_id: Option<PeerId>) {
-        self.addr_to_peer.insert(multi_addr.clone(), peer_id);
+    pub fn len(&self) -> usize {
+        self.peer_to_addr.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.peer_to_addr.is_empty()
+    }
+
+    pub fn add_peer(&mut self, multi_addr: Multiaddr, peer_id: Option<PeerId>, conn_type: ConnectionType) {
+        self.addr_to_peer
+            .insert(multi_addr.clone(), PeerInfo { peer_id, conn_type });
 
         if let Some(peer) = peer_id {
             self.peer_to_addr.insert(peer, multi_addr);
         }
     }
 
+    pub fn get_peer_by_id(&mut self, peer_id: &PeerId) -> Option<(Multiaddr, PeerInfo)> {
+        if let Some(addr) = self.peer_to_addr.get(peer_id) {
+            if let Some(peer_info) = self.addr_to_peer.get(addr) {
+                return Some((addr.clone(), peer_info.clone()));
+            }
+        }
+
+        None
+    }
+
+    pub fn get_peer_by_addr(&mut self, addr: &Multiaddr) -> Option<PeerInfo> {
+        if let Some(peer_info) = self.addr_to_peer.get(addr) {
+            return Some(peer_info.clone());
+        }
+
+        None
+    }
+
     pub fn set_peer_id(&mut self, multi_addr: Multiaddr, peer_id: PeerId) {
-        self.addr_to_peer.insert(multi_addr.clone(), Some(peer_id));
+        let mut peer_info = self.addr_to_peer.get(&multi_addr).unwrap().clone();
+        peer_info.peer_id = Some(peer_id);
+
+        self.addr_to_peer.insert(multi_addr.clone(), peer_info);
         self.peer_to_addr.insert(peer_id, multi_addr);
     }
 
-    pub fn remove_peer_by_addr(&mut self, multi_addr: Multiaddr) {
-        let item = self.addr_to_peer.get(&multi_addr);
+    pub fn remove_peer_by_addr(&mut self, multi_addr: &Multiaddr) {
+        let item = self.addr_to_peer.get(multi_addr);
 
-        if let Some(Some(peer_id)) = item {
-            self.peer_to_addr.remove(peer_id);
+        if let Some(peer_info) = item {
+            if let Some(peer_id) = peer_info.peer_id {
+                self.peer_to_addr.remove(&peer_id);
+            }
         }
 
-        self.addr_to_peer.remove(&multi_addr);
+        self.addr_to_peer.remove(multi_addr);
     }
 
-    pub fn remove_peer_by_id(&mut self, peer_id: PeerId) {
-        let addr = self.peer_to_addr.get(&peer_id);
+    pub fn remove_peer_by_id(&mut self, peer_id: &PeerId) {
+        let addr = self.peer_to_addr.get(peer_id);
 
         if let Some(multi_addr) = addr {
             self.addr_to_peer.remove(multi_addr);
         }
 
-        self.peer_to_addr.remove(&peer_id);
+        self.peer_to_addr.remove(peer_id);
+    }
+
+    pub fn has_peer_id(&self, peer_id: &PeerId) -> bool {
+        self.peer_to_addr.contains_key(peer_id)
+    }
+
+    pub fn has_addr(&self, addr: &Multiaddr) -> bool {
+        self.addr_to_peer.contains_key(addr)
     }
 
     pub fn get_json(&self) -> Value {
@@ -67,5 +129,9 @@ impl PeerList {
 
     pub fn get_all(&self) -> HashMap<PeerId, Multiaddr> {
         self.peer_to_addr.clone()
+    }
+
+    pub fn get_all_info(&self) -> HashMap<Multiaddr, PeerInfo> {
+        self.addr_to_peer.clone()
     }
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

We want the node to always try to connect to a certain amount of peers using different discovery methods. This implements a manager that allows for this functionality. 


## Explanation of Changes

This implements a "waterfall" peer manager that tries to connect to peers in the following order:
* Manual peers
* mDNS peers
* Chain peers (not implemented)
* Kademlia peers
 
It goes one by one and checks if there are any peers to connect to. If not it will go to the next discovery method. If all methods are exhausted it will ask kademlia to search the network for new peers.
If a peer is not reachable it will be put inside the cooldown list, which the node will not retry for a certain amount of time. After which the node retries the connection.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

The discovery methods are untouched, you can test this by using mDNS (spin up two nodes and wait for them to find each other) or use manual peers. If you want to test kademlia you have to disable all methods but kademlia and connect the nodes together through the CLI.
