### PR TITLE
feat(contracts): implement committee bootstrapping

### DIFF
--- a/contracts/src/batch.rs
+++ b/contracts/src/batch.rs
@@ -56,14 +56,20 @@ impl MainchainContract {
         // eligible for this batch while also verifying individual eligibility
 
         // 1. initialize with the first signer
-        self.assert_eligible_for_current_epoch(&signers[0]);
+        assert!(
+            self.active_nodes.get(&signers[0]).is_some(),
+            "Node is not active"
+        );
         let mut aggregate_public_key_check =
-            PublicKey::from_compressed(self.nodes.get(&signers[0]).unwrap().bn254_public_key).unwrap();
+            PublicKey::from_compressed(self.active_nodes.get(&signers[0]).unwrap().bn254_public_key).unwrap();
         // 2. add the rest of the signers' public keys
         for signer in signers.iter().skip(1) {
-            self.assert_eligible_for_current_epoch(signer); // TODO: store in a vector of eligible signers for this epoch
+            assert!(
+                self.active_nodes.get(&signer).is_some(),
+                "Node is not active"
+            );
             let signer_public_key =
-                PublicKey::from_compressed(self.nodes.get(signer).unwrap().bn254_public_key).unwrap();
+                PublicKey::from_compressed(self.active_nodes.get(signer).unwrap().bn254_public_key).unwrap();
             aggregate_public_key_check = aggregate_public_key_check + signer_public_key;
         }
         assert!(

--- a/contracts/src/batch.rs
+++ b/contracts/src/batch.rs
@@ -62,20 +62,21 @@ impl MainchainContract {
 
         // reconstruct the aggregate public key from signers[] to verify all signers are
         // eligible for this batch while also verifying individual eligibility
-
-        // 1. initialize with the first signer
-        assert!(self.committees[0].contains(&signers[0]), "Node is not active");
-        let mut aggregate_public_key_check =
-            PublicKey::from_compressed(self.active_nodes.get(&signers[0]).unwrap().bn254_public_key).unwrap();
-        // 2. add the rest of the signers' public keys
-        for signer in signers.iter().skip(1) {
-            assert!(self.committees[0].contains(signer), "Node is not active");
-            let signer_public_key =
-                PublicKey::from_compressed(self.active_nodes.get(signer).unwrap().bn254_public_key).unwrap();
-            aggregate_public_key_check = aggregate_public_key_check + signer_public_key;
-        }
         assert!(
-            aggregate_public_key_check.to_compressed().unwrap() == aggregate_public_key,
+            self.committees[0].contains(&signers[0]),
+            "Node is not part of the committee"
+        );
+        let aggregate_public_key_reconstructed = signers.iter().skip(1).fold(
+            PublicKey::from_compressed(self.active_nodes.get(&signers[0]).unwrap().bn254_public_key).unwrap(),
+            |acc, signer| {
+                assert!(self.committees[0].contains(signer), "Node is not part of the committee");
+                let signer_public_key =
+                    PublicKey::from_compressed(self.active_nodes.get(signer).unwrap().bn254_public_key).unwrap();
+                acc + signer_public_key
+            },
+        );
+        assert!(
+            aggregate_public_key_reconstructed.to_compressed().unwrap() == aggregate_public_key,
             "Invalid aggregate public key"
         );
 

--- a/contracts/src/batch.rs
+++ b/contracts/src/batch.rs
@@ -56,18 +56,12 @@ impl MainchainContract {
         // eligible for this batch while also verifying individual eligibility
 
         // 1. initialize with the first signer
-        assert!(
-            self.active_nodes.get(&signers[0]).is_some(),
-            "Node is not active"
-        );
+        assert!(self.active_nodes.get(&signers[0]).is_some(), "Node is not active");
         let mut aggregate_public_key_check =
             PublicKey::from_compressed(self.active_nodes.get(&signers[0]).unwrap().bn254_public_key).unwrap();
         // 2. add the rest of the signers' public keys
         for signer in signers.iter().skip(1) {
-            assert!(
-                self.active_nodes.get(&signer).is_some(),
-                "Node is not active"
-            );
+            assert!(self.active_nodes.get(signer).is_some(), "Node is not active");
             let signer_public_key =
                 PublicKey::from_compressed(self.active_nodes.get(signer).unwrap().bn254_public_key).unwrap();
             aggregate_public_key_check = aggregate_public_key_check + signer_public_key;

--- a/contracts/src/batch_test.rs
+++ b/contracts/src/batch_test.rs
@@ -4,7 +4,6 @@ use near_sdk::{json_types::U128, testing_env};
 use super::test_utils::{
     bn254_sign,
     generate_bn254_key,
-    get_context,
     get_context_for_ft_transfer,
     get_context_for_post_signed_batch,
     get_context_with_deposit,
@@ -12,7 +11,7 @@ use super::test_utils::{
 };
 
 #[test]
-fn post_data_request() {
+fn post_signed_batch() {
     let mut contract = new_contract();
     let deposit_amount = U128(100_000_000_000_000_000_000_000);
 
@@ -49,9 +48,9 @@ fn post_data_request() {
     );
 
     // alice and bob deposit into contract
-    testing_env!(get_context("alice_near".to_string()));
+    testing_env!(get_context_with_deposit("alice_near".to_string()));
     contract.deposit(deposit_amount);
-    testing_env!(get_context("bob_near".to_string()));
+    testing_env!(get_context_with_deposit("bob_near".to_string()));
     contract.deposit(deposit_amount);
 
     // get the merkle root (for all nodes to sign)

--- a/contracts/src/committee.rs
+++ b/contracts/src/committee.rs
@@ -1,0 +1,25 @@
+use near_sdk::{near_bindgen, AccountId};
+
+use crate::{consts::SLOTS_PER_EPOCH, MainchainContract, MainchainContractExt};
+
+/// Contract private methods
+impl MainchainContract {
+    pub fn select_committee(&mut self) -> Vec<AccountId> {
+        // TODO: committee selection algorithm
+        // temp: fill the committee with active nodes round robin style
+        let mut committee = vec![];
+        let active_nodes_vec = self.active_nodes.keys_as_vector();
+        for i in 0..SLOTS_PER_EPOCH {
+            committee.push(active_nodes_vec.get(i % active_nodes_vec.len()).unwrap());
+        }
+        committee
+    }
+}
+
+/// Contract public methods
+#[near_bindgen]
+impl MainchainContract {
+    pub fn get_committees(&self) -> Vec<Vec<AccountId>> {
+        self.committees.clone()
+    }
+}

--- a/contracts/src/consts.rs
+++ b/contracts/src/consts.rs
@@ -7,7 +7,7 @@ pub const DATA_IMAGE_SVG_ICON: &str = "data:image/svg+xml,%3Csvg xmlns='http://w
 pub const INITIAL_SUPPLY: u128 = 100_000_000_000_000_000_000_000_000; // 1000 SEDA
 pub const INIT_MINIMUM_STAKE: u128 = 100_000_000_000_000_000_000_000; // 100 SEDA
 pub const INIT_EPOCH_DELAY_FOR_ELECTION: u64 = 2;
-pub const INIT_RANDOM_SEED: u128 = 5304;
 pub const INIT_COMMITTEE_SIZE: u64 = 10;
 pub const SLOTS_PER_EPOCH: u64 = 32;
 pub const NEAR_BLOCKS_PER_SEDA_SLOT: u64 = 10; // at 1.2s/block, 12s/slot
+pub const EPOCH_COMMITTEES_LOOKAHEAD: u64 = 2;

--- a/contracts/src/consts.rs
+++ b/contracts/src/consts.rs
@@ -7,7 +7,7 @@ pub const DATA_IMAGE_SVG_ICON: &str = "data:image/svg+xml,%3Csvg xmlns='http://w
 pub const INITIAL_SUPPLY: u128 = 100_000_000_000_000_000_000_000_000; // 1000 SEDA
 pub const INIT_MINIMUM_STAKE: u128 = 100_000_000_000_000_000_000_000; // 100 SEDA
 pub const INIT_EPOCH_DELAY_FOR_ELECTION: u64 = 2;
-pub const INIT_COMMITTEE_SIZE: u64 = 10;
+pub const DEFAULT_COMMITTEE_SIZE: u64 = 128;
 pub const SLOTS_PER_EPOCH: u64 = 32;
 pub const NEAR_BLOCKS_PER_SEDA_SLOT: u64 = 10; // at 1.2s/block, 12s/slot
 pub const EPOCH_COMMITTEES_LOOKAHEAD: u64 = 2;

--- a/contracts/src/consts.rs
+++ b/contracts/src/consts.rs
@@ -7,3 +7,7 @@ pub const DATA_IMAGE_SVG_ICON: &str = "data:image/svg+xml,%3Csvg xmlns='http://w
 pub const INITIAL_SUPPLY: u128 = 100_000_000_000_000_000_000_000_000; // 1000 SEDA
 pub const INIT_MINIMUM_STAKE: u128 = 100_000_000_000_000_000_000_000; // 100 SEDA
 pub const INIT_EPOCH_DELAY_FOR_ELECTION: u64 = 2;
+pub const INIT_RANDOM_SEED: u128 = 5304;
+pub const INIT_COMMITTEE_SIZE: u64 = 10;
+pub const SLOTS_PER_EPOCH: u64 = 32;
+pub const NEAR_BLOCKS_PER_SEDA_SLOT: u64 = 10; // at 1.2s/block, 12s/slot

--- a/contracts/src/dao.rs
+++ b/contracts/src/dao.rs
@@ -7,7 +7,7 @@ use near_sdk::{
 };
 
 use crate::{
-    consts::{INIT_EPOCH_DELAY_FOR_ELECTION, INIT_MINIMUM_STAKE},
+    consts::{INIT_EPOCH_DELAY_FOR_ELECTION, INIT_MINIMUM_STAKE, INIT_COMMITTEE_SIZE},
     MainchainContract,
     MainchainContractExt,
 };
@@ -16,6 +16,7 @@ use crate::{
 pub struct Config {
     pub minimum_stake:            u128,
     pub epoch_delay_for_election: u64,
+    pub committee_size:           u64,
 }
 
 impl Default for Config {
@@ -23,6 +24,7 @@ impl Default for Config {
         Self {
             minimum_stake:            INIT_MINIMUM_STAKE,
             epoch_delay_for_election: INIT_EPOCH_DELAY_FOR_ELECTION,
+            committee_size:           INIT_COMMITTEE_SIZE,
         }
     }
 }

--- a/contracts/src/dao.rs
+++ b/contracts/src/dao.rs
@@ -7,7 +7,7 @@ use near_sdk::{
 };
 
 use crate::{
-    consts::{INIT_COMMITTEE_SIZE, INIT_EPOCH_DELAY_FOR_ELECTION, INIT_MINIMUM_STAKE},
+    consts::{DEFAULT_COMMITTEE_SIZE, INIT_EPOCH_DELAY_FOR_ELECTION, INIT_MINIMUM_STAKE},
     MainchainContract,
     MainchainContractExt,
 };
@@ -24,7 +24,7 @@ impl Default for Config {
         Self {
             minimum_stake:            INIT_MINIMUM_STAKE,
             epoch_delay_for_election: INIT_EPOCH_DELAY_FOR_ELECTION,
-            committee_size:           INIT_COMMITTEE_SIZE,
+            committee_size:           DEFAULT_COMMITTEE_SIZE,
         }
     }
 }

--- a/contracts/src/dao.rs
+++ b/contracts/src/dao.rs
@@ -7,7 +7,7 @@ use near_sdk::{
 };
 
 use crate::{
-    consts::{INIT_EPOCH_DELAY_FOR_ELECTION, INIT_MINIMUM_STAKE, INIT_COMMITTEE_SIZE},
+    consts::{INIT_COMMITTEE_SIZE, INIT_EPOCH_DELAY_FOR_ELECTION, INIT_MINIMUM_STAKE},
     MainchainContract,
     MainchainContractExt,
 };

--- a/contracts/src/data_request_test.rs
+++ b/contracts/src/data_request_test.rs
@@ -26,15 +26,3 @@ fn post_data_request_no_deposit() {
     testing_env!(get_context("bob_near".to_string()));
     contract.post_data_request("data_request_1".to_string());
 }
-
-#[test]
-fn merkle_gas_tests() {
-    let mut contract = new_contract();
-
-    for i in 0..300 {
-        testing_env!(get_context_with_deposit("bob_near".to_string()));
-        contract.post_data_request(format!("data_request_{}", i));
-        testing_env!(get_context("bob_near".to_string()));
-        contract.compute_merkle_root();
-    }
-}

--- a/contracts/src/epoch.rs
+++ b/contracts/src/epoch.rs
@@ -1,8 +1,28 @@
-use near_sdk::{env, near_bindgen, log};
+use near_sdk::{env, log, near_bindgen, AccountId};
 
-use crate::{consts::{NEAR_BLOCKS_PER_SEDA_SLOT, SLOTS_PER_EPOCH, INIT_COMMITTEE_SIZE}, MainchainContract, MainchainContractExt};
+use crate::{
+    consts::{EPOCH_COMMITTEES_LOOKAHEAD, INIT_COMMITTEE_SIZE, NEAR_BLOCKS_PER_SEDA_SLOT, SLOTS_PER_EPOCH},
+    MainchainContract,
+    MainchainContractExt,
+};
 
 pub type EpochHeight = u64;
+
+/// Contract private methods
+impl MainchainContract {
+    fn select_committee(&mut self) -> Vec<AccountId> {
+        // temporarily select the first config.committee_size nodes from active nodes
+        // TODO: implement committee selection algorithm
+        let mut committee = vec![];
+        for (account_id, _) in self.active_nodes.iter() {
+            if committee.len() as u64 == self.config.committee_size {
+                break;
+            }
+            committee.push(account_id.clone());
+        }
+        committee
+    }
+}
 
 /// Contract public methods
 #[near_bindgen]
@@ -17,7 +37,7 @@ impl MainchainContract {
             log!("Epoch has already been processed");
             return;
         }
-        
+
         // if bootstrapping phase, wait until there are INIT_COMMITTEE_SIZE active nodes
         if self.bootstrapping_phase {
             if self.active_nodes.len() < INIT_COMMITTEE_SIZE {
@@ -25,12 +45,18 @@ impl MainchainContract {
                 return;
             }
             self.bootstrapping_phase = false;
+            // select committees EPOCH_COMMITTEES_LOOKAHEAD epochs in advance
+            for _ in 1..EPOCH_COMMITTEES_LOOKAHEAD {
+                let committee = self.select_committee();
+                self.committees.push(committee);
+            }
         }
 
         // move pending nodes to active nodes if they are eligible for this epoch
         self.pending_nodes.to_vec().retain(|(account_id, activation_epoch)| {
             if activation_epoch == &self.get_current_epoch() {
-                self.active_nodes.insert(&account_id, &self.inactive_nodes.get(&account_id).unwrap());
+                self.active_nodes
+                    .insert(account_id, &self.inactive_nodes.get(account_id).unwrap());
                 false
             } else {
                 true
@@ -38,16 +64,8 @@ impl MainchainContract {
         });
 
         // select committee from active nodes
-        // temporarily just select the first config.committee_size nodes
-        // TODO: implement committee selection algorithm
-        let mut committee = vec![];
-        for (account_id, _) in self.active_nodes.iter() {
-            if committee.len() as u64 == self.config.committee_size {
-                break;
-            }
-            committee.push(account_id.clone());
-        }
-        self.committee = committee;
+        let committee = self.select_committee();
+        self.committees.push(committee);
 
         // set last processed epoch to current epoch
         self.last_processed_epoch = self.get_current_epoch();

--- a/contracts/src/epoch.rs
+++ b/contracts/src/epoch.rs
@@ -1,13 +1,55 @@
-use near_sdk::{env, near_bindgen};
+use near_sdk::{env, near_bindgen, log};
 
-use crate::{slot::NEAR_BLOCKS_PER_SEDA_SLOT, MainchainContract, MainchainContractExt};
+use crate::{consts::{NEAR_BLOCKS_PER_SEDA_SLOT, SLOTS_PER_EPOCH, INIT_COMMITTEE_SIZE}, MainchainContract, MainchainContractExt};
 
-pub const SLOTS_PER_EPOCH: u64 = 32;
+pub type EpochHeight = u64;
 
 /// Contract public methods
 #[near_bindgen]
 impl MainchainContract {
     pub fn get_current_epoch(&self) -> u64 {
         env::block_height() / (NEAR_BLOCKS_PER_SEDA_SLOT * SLOTS_PER_EPOCH)
+    }
+
+    pub fn process_epoch(&mut self) {
+        // check if epoch has already been processed
+        if self.get_current_epoch() <= self.last_processed_epoch {
+            log!("Epoch has already been processed");
+            return;
+        }
+        
+        // if bootstrapping phase, wait until there are INIT_COMMITTEE_SIZE active nodes
+        if self.bootstrapping_phase {
+            if self.active_nodes.len() < INIT_COMMITTEE_SIZE {
+                log!("Not enough active nodes to exit bootstrapping phase");
+                return;
+            }
+            self.bootstrapping_phase = false;
+        }
+
+        // move pending nodes to active nodes if they are eligible for this epoch
+        self.pending_nodes.to_vec().retain(|(account_id, activation_epoch)| {
+            if activation_epoch == &self.get_current_epoch() {
+                self.active_nodes.insert(&account_id, &self.inactive_nodes.get(&account_id).unwrap());
+                false
+            } else {
+                true
+            }
+        });
+
+        // select committee from active nodes
+        // temporarily just select the first config.committee_size nodes
+        // TODO: implement committee selection algorithm
+        let mut committee = vec![];
+        for (account_id, _) in self.active_nodes.iter() {
+            if committee.len() as u64 == self.config.committee_size {
+                break;
+            }
+            committee.push(account_id.clone());
+        }
+        self.committee = committee;
+
+        // set last processed epoch to current epoch
+        self.last_processed_epoch = self.get_current_epoch();
     }
 }

--- a/contracts/src/epoch.rs
+++ b/contracts/src/epoch.rs
@@ -1,28 +1,13 @@
-use near_sdk::{env, log, near_bindgen, AccountId};
+use near_sdk::{env, log, near_bindgen};
 
 use crate::{
-    consts::{EPOCH_COMMITTEES_LOOKAHEAD, INIT_COMMITTEE_SIZE, NEAR_BLOCKS_PER_SEDA_SLOT, SLOTS_PER_EPOCH},
+    consts::{EPOCH_COMMITTEES_LOOKAHEAD, NEAR_BLOCKS_PER_SEDA_SLOT, SLOTS_PER_EPOCH},
+    manage_storage_deposit,
     MainchainContract,
     MainchainContractExt,
 };
 
 pub type EpochHeight = u64;
-
-/// Contract private methods
-impl MainchainContract {
-    fn select_committee(&mut self) -> Vec<AccountId> {
-        // temporarily select the first config.committee_size nodes from active nodes
-        // TODO: implement committee selection algorithm
-        let mut committee = vec![];
-        for (account_id, _) in self.active_nodes.iter() {
-            if committee.len() as u64 == self.config.committee_size {
-                break;
-            }
-            committee.push(account_id.clone());
-        }
-        committee
-    }
-}
 
 /// Contract public methods
 #[near_bindgen]
@@ -32,42 +17,55 @@ impl MainchainContract {
     }
 
     pub fn process_epoch(&mut self) {
-        // check if epoch has already been processed
-        if self.get_current_epoch() <= self.last_processed_epoch {
-            log!("Epoch has already been processed");
-            return;
-        }
-
-        // if bootstrapping phase, wait until there are INIT_COMMITTEE_SIZE active nodes
-        if self.bootstrapping_phase {
-            if self.active_nodes.len() < INIT_COMMITTEE_SIZE {
-                log!("Not enough active nodes to exit bootstrapping phase");
+        manage_storage_deposit!(self, "require", {
+            // check if epoch has already been processed
+            if self.get_current_epoch() <= self.last_processed_epoch {
+                log!("Epoch has already been processed");
                 return;
             }
-            self.bootstrapping_phase = false;
-            // select committees EPOCH_COMMITTEES_LOOKAHEAD epochs in advance
-            for _ in 1..EPOCH_COMMITTEES_LOOKAHEAD {
-                let committee = self.select_committee();
-                self.committees.push(committee);
-            }
-        }
 
-        // move pending nodes to active nodes if they are eligible for this epoch
-        self.pending_nodes.to_vec().retain(|(account_id, activation_epoch)| {
-            if activation_epoch == &self.get_current_epoch() {
-                self.active_nodes
-                    .insert(account_id, &self.inactive_nodes.get(account_id).unwrap());
-                false
+            // move pending nodes to active nodes if they are eligible for this epoch
+            self.pending_nodes.to_vec().retain(|(account_id, activation_epoch)| {
+                if activation_epoch <= &self.get_current_epoch() {
+                    self.active_nodes
+                        .insert(account_id, &self.inactive_nodes.get(account_id).unwrap());
+                    // log!("Moving pending node {} to active nodes", account_id);
+                    false
+                } else {
+                    true
+                }
+            });
+            log!("pending_nodes: {:?}", self.pending_nodes.to_vec());
+
+            // if bootstrapping phase, wait until there are committee_size active nodes
+            if self.bootstrapping_phase {
+                if self.active_nodes.len() < self.config.committee_size {
+                    log!("Not enough active nodes to exit bootstrapping phase");
+                    return;
+                }
+                self.bootstrapping_phase = false;
+                log!("Exiting bootstrapping phase");
+                // select committees EPOCH_COMMITTEES_LOOKAHEAD epochs in advance
+                for _ in 0..EPOCH_COMMITTEES_LOOKAHEAD {
+                    let committee = self.select_committee();
+                    self.committees.push(committee);
+                }
             } else {
-                true
+                // remove committee of last epoch
+                self.committees.remove(0);
             }
+
+            // select committee from active nodes
+            let committee = self.select_committee();
+            log!(
+                "Selected committee for epoch {}: {:?}",
+                self.get_current_epoch(),
+                committee
+            );
+            self.committees.push(committee);
+
+            // set last processed epoch to current epoch
+            self.last_processed_epoch = self.get_current_epoch();
         });
-
-        // select committee from active nodes
-        let committee = self.select_committee();
-        self.committees.push(committee);
-
-        // set last processed epoch to current epoch
-        self.last_processed_epoch = self.get_current_epoch();
     }
 }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod batch;
+pub mod committee;
 pub mod consts;
 pub mod dao;
 pub mod data_request;
@@ -58,15 +59,14 @@ pub struct MainchainContract {
 
     // TODO: do all of these need to be UnorderedMaps?
     // Nodes that are eligible to participate in the current epoch
-    active_nodes:   UnorderedMap<AccountId, Node>,
+    active_nodes:              UnorderedMap<AccountId, Node>,
     // Nodes that are not eligible to participate in the current epoch
-    inactive_nodes: UnorderedMap<AccountId, Node>,
+    inactive_nodes:            UnorderedMap<AccountId, Node>,
     // Sub-set of inactive nodes that are waiting to be activated
-    pending_nodes:  UnorderedMap<AccountId, EpochHeight>,
+    pending_nodes:             UnorderedMap<AccountId, EpochHeight>,
     // Sub-set of active nodes that are part of the committee of the current epoch
     // committees[EPOCH_COMMITTEES_LOOKAHEAD + 1][SLOTS_PER_EPOCH]
-    committees:     Vec<Vec<AccountId>>,
-
+    committees:                Vec<Vec<AccountId>>,
     data_request_accumulator:  Vector<String>,
     num_batches:               BatchHeight,
     batch_ids_by_height:       LookupMap<BatchHeight, BatchId>,
@@ -82,31 +82,35 @@ pub struct MainchainContract {
 #[near_bindgen]
 impl MainchainContract {
     #[init]
-    pub fn new(dao: AccountId, initial_supply: U128, metadata: FungibleTokenMetadata) -> Self {
+    pub fn new(dao: AccountId, initial_supply: U128, metadata: FungibleTokenMetadata, committee_size: u64) -> Self {
         assert!(!env::state_exists(), "Already initialized");
         assert!(
             env::is_valid_account_id(dao.as_bytes()),
             "The DAO account ID is invalid"
         );
+        let config = dao::Config {
+            committee_size,
+            ..Default::default()
+        };
         metadata.assert_valid();
         let mut this = Self {
-            token:                     FungibleToken::new(MainchainStorageKeys::FungibleToken),
-            metadata:                  LazyOption::new(MainchainStorageKeys::FungibleTokenMetadata, Some(&metadata)),
-            dao:                       dao.clone(),
-            config:                    dao::Config::default(),
-            active_nodes:              UnorderedMap::new(MainchainStorageKeys::ActiveNodes),
-            inactive_nodes:            UnorderedMap::new(MainchainStorageKeys::InactiveNodes),
-            pending_nodes:             UnorderedMap::new(MainchainStorageKeys::PendingNodes),
-            committees:                Vec::new(),
-            data_request_accumulator:  Vector::<String>::new(MainchainStorageKeys::DataRequestAccumulator),
-            num_batches:               0,
-            batch_ids_by_height:       LookupMap::new(MainchainStorageKeys::BatchIdsByHeight),
-            batch_by_id:               LookupMap::new(MainchainStorageKeys::BatchById),
-            last_total_balance:        0,
+            token: FungibleToken::new(MainchainStorageKeys::FungibleToken),
+            metadata: LazyOption::new(MainchainStorageKeys::FungibleTokenMetadata, Some(&metadata)),
+            dao: dao.clone(),
+            config,
+            active_nodes: UnorderedMap::new(MainchainStorageKeys::ActiveNodes),
+            inactive_nodes: UnorderedMap::new(MainchainStorageKeys::InactiveNodes),
+            pending_nodes: UnorderedMap::new(MainchainStorageKeys::PendingNodes),
+            committees: Vec::new(),
+            data_request_accumulator: Vector::<String>::new(MainchainStorageKeys::DataRequestAccumulator),
+            num_batches: 0,
+            batch_ids_by_height: LookupMap::new(MainchainStorageKeys::BatchIdsByHeight),
+            batch_by_id: LookupMap::new(MainchainStorageKeys::BatchById),
+            last_total_balance: 0,
             nodes_by_bn254_public_key: LookupMap::new(MainchainStorageKeys::NodesByBn254PublicKey),
-            random_seed:               CryptoHash::default(),
-            bootstrapping_phase:       true,
-            last_processed_epoch:      0,
+            random_seed: CryptoHash::default(),
+            bootstrapping_phase: true,
+            last_processed_epoch: 0,
         };
         this.token.internal_register_account(&dao);
         this.token.internal_deposit(&dao, initial_supply.into());

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -43,7 +43,7 @@ fn register_and_get_node() {
 }
 
 #[test]
-#[should_panic(expected = "Insufficient storage, need 4050000000000000000000")]
+#[should_panic(expected = "Insufficient storage, need 3970000000000000000000")]
 fn register_not_enough_storage() {
     let mut contract = new_contract();
     let (bob_public_key, bob_private_key) = generate_bn254_key();
@@ -125,21 +125,18 @@ fn get_nodes() {
         account_id:          "bob_near".to_string().try_into().unwrap(),
         balance:             0,
         multi_addr:          "0.0.0.0:8080".to_string(),
-        epoch_when_eligible: U64(0),
         bn254_public_key:    bob_public_key.to_compressed().unwrap(),
     };
     let node2 = HumanReadableNode {
         account_id:          "alice_near".to_string().try_into().unwrap(),
         balance:             0,
         multi_addr:          "1.1.1.1:8080".to_string(),
-        epoch_when_eligible: U64(0),
         bn254_public_key:    alice_public_key.to_compressed().unwrap(),
     };
     let node3 = HumanReadableNode {
         account_id:          "carol_near".to_string().try_into().unwrap(),
         balance:             0,
         multi_addr:          "2.2.2.2:8080".to_string(),
-        epoch_when_eligible: U64(0),
         bn254_public_key:    carol_public_key.to_compressed().unwrap(),
     };
 
@@ -208,7 +205,7 @@ fn deposit_withdraw() {
     );
 
     // alice deposits into pool
-    testing_env!(get_context("alice_near".to_string()));
+    testing_env!(get_context_with_deposit("alice_near".to_string()));
     contract.deposit(deposit_amount);
 
     // check alice's balance is now zero
@@ -227,7 +224,7 @@ fn deposit_withdraw() {
     let node_balance = contract.get_node_balance("alice_near".to_string().try_into().unwrap());
     assert_eq!(node_balance, deposit_amount);
 
-    // time travel to an epoch where alice is active
+    // time travel to an epoch where alice is eligible to be included in a committee
     testing_env!(get_context_at_block(1000000));
     assert_eq!(
         contract.is_node_active("alice_near".to_string().try_into().unwrap()),

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -9,7 +9,6 @@ use super::test_utils::{
     bn254_sign,
     generate_bn254_key,
     get_context,
-    get_context_at_block,
     get_context_for_ft_transfer,
     get_context_view,
     get_context_with_deposit,
@@ -122,22 +121,22 @@ fn get_nodes() {
 
     // define expected nodes
     let node1 = HumanReadableNode {
-        account_id:          "bob_near".to_string().try_into().unwrap(),
-        balance:             0,
-        multi_addr:          "0.0.0.0:8080".to_string(),
-        bn254_public_key:    bob_public_key.to_compressed().unwrap(),
+        account_id:       "bob_near".to_string().try_into().unwrap(),
+        balance:          0,
+        multi_addr:       "0.0.0.0:8080".to_string(),
+        bn254_public_key: bob_public_key.to_compressed().unwrap(),
     };
     let node2 = HumanReadableNode {
-        account_id:          "alice_near".to_string().try_into().unwrap(),
-        balance:             0,
-        multi_addr:          "1.1.1.1:8080".to_string(),
-        bn254_public_key:    alice_public_key.to_compressed().unwrap(),
+        account_id:       "alice_near".to_string().try_into().unwrap(),
+        balance:          0,
+        multi_addr:       "1.1.1.1:8080".to_string(),
+        bn254_public_key: alice_public_key.to_compressed().unwrap(),
     };
     let node3 = HumanReadableNode {
-        account_id:          "carol_near".to_string().try_into().unwrap(),
-        balance:             0,
-        multi_addr:          "2.2.2.2:8080".to_string(),
-        bn254_public_key:    carol_public_key.to_compressed().unwrap(),
+        account_id:       "carol_near".to_string().try_into().unwrap(),
+        balance:          0,
+        multi_addr:       "2.2.2.2:8080".to_string(),
+        bn254_public_key: carol_public_key.to_compressed().unwrap(),
     };
 
     // get the first node
@@ -223,13 +222,6 @@ fn deposit_withdraw() {
     // check alice's deposited amount
     let node_balance = contract.get_node_balance("alice_near".to_string().try_into().unwrap());
     assert_eq!(node_balance, deposit_amount);
-
-    // time travel to an epoch where alice is eligible to be included in a committee
-    testing_env!(get_context_at_block(1000000));
-    assert_eq!(
-        contract.is_node_active("alice_near".to_string().try_into().unwrap()),
-        true
-    );
 
     // alice withdraws
     testing_env!(get_context("alice_near".to_string()));

--- a/contracts/src/slot.rs
+++ b/contracts/src/slot.rs
@@ -1,7 +1,6 @@
 use near_sdk::{env, near_bindgen};
 
-use crate::{MainchainContract, MainchainContractExt};
-use crate::consts::NEAR_BLOCKS_PER_SEDA_SLOT;
+use crate::{consts::NEAR_BLOCKS_PER_SEDA_SLOT, MainchainContract, MainchainContractExt};
 
 /// Contract public methods
 #[near_bindgen]

--- a/contracts/src/slot.rs
+++ b/contracts/src/slot.rs
@@ -1,8 +1,7 @@
 use near_sdk::{env, near_bindgen};
 
 use crate::{MainchainContract, MainchainContractExt};
-
-pub const NEAR_BLOCKS_PER_SEDA_SLOT: u64 = 10; // at 1.2s/block, 12s/slot
+use crate::consts::NEAR_BLOCKS_PER_SEDA_SLOT;
 
 /// Contract public methods
 #[near_bindgen]

--- a/contracts/src/slot_test.rs
+++ b/contracts/src/slot_test.rs
@@ -1,7 +1,7 @@
 use near_sdk::testing_env;
 
 use super::test_utils::{get_context_at_block, new_contract};
-use crate::{epoch::SLOTS_PER_EPOCH, slot::NEAR_BLOCKS_PER_SEDA_SLOT};
+use crate::{consts::{SLOTS_PER_EPOCH, NEAR_BLOCKS_PER_SEDA_SLOT}};
 
 #[test]
 fn get_current_slot() {

--- a/contracts/src/slot_test.rs
+++ b/contracts/src/slot_test.rs
@@ -1,7 +1,7 @@
 use near_sdk::testing_env;
 
 use super::test_utils::{get_context_at_block, new_contract};
-use crate::{consts::{SLOTS_PER_EPOCH, NEAR_BLOCKS_PER_SEDA_SLOT}};
+use crate::consts::{NEAR_BLOCKS_PER_SEDA_SLOT, SLOTS_PER_EPOCH};
 
 #[test]
 fn get_current_slot() {

--- a/contracts/src/test_utils.rs
+++ b/contracts/src/test_utils.rs
@@ -13,7 +13,6 @@ use crate::{
 pub fn new_contract() -> MainchainContract {
     MainchainContract::new(
         "dao_near".to_string().try_into().unwrap(),
-        "seda_token".to_string().try_into().unwrap(),
         U128(INITIAL_SUPPLY),
         FungibleTokenMetadata {
             spec:           FT_METADATA_SPEC.to_string(),

--- a/contracts/src/test_utils.rs
+++ b/contracts/src/test_utils.rs
@@ -1,12 +1,14 @@
 use bn254::{PrivateKey, PublicKey, Signature, ECDSA};
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
-use near_sdk::{json_types::U128, test_utils::VMContextBuilder, VMContext};
+use near_sdk::{json_types::U128, test_utils::VMContextBuilder, Balance, VMContext};
 use rand::distributions::{Alphanumeric, DistString};
 
 use crate::{
     consts::{DATA_IMAGE_SVG_ICON, INITIAL_SUPPLY},
     MainchainContract,
 };
+
+const TEST_DEPOSIT_AMOUNT: Balance = 9_000_000_000_000_000_000_000; // enough deposit to cover storage for all functions that require it
 
 // TODO: only compile this for tests
 
@@ -23,6 +25,7 @@ pub fn new_contract() -> MainchainContract {
             reference_hash: None,
             decimals:       24,
         },
+        2,
     )
 }
 
@@ -40,7 +43,7 @@ pub fn get_context_for_post_signed_batch(signer_account_id: String) -> VMContext
     VMContextBuilder::new()
         .signer_account_id(signer_account_id.parse().unwrap())
         .is_view(false)
-        .attached_deposit(4_110_000_000_000_000_000_000)
+        .attached_deposit(TEST_DEPOSIT_AMOUNT)
         .block_index(100000000)
         .build()
 }
@@ -48,7 +51,7 @@ pub fn get_context_with_deposit(signer_account_id: String) -> VMContext {
     VMContextBuilder::new()
         .signer_account_id(signer_account_id.parse().unwrap())
         .is_view(false)
-        .attached_deposit(4_110_000_000_000_000_000_000) // required for post_data_request()
+        .attached_deposit(TEST_DEPOSIT_AMOUNT) // required for post_data_request()
         .build()
 }
 pub fn get_context_for_ft_transfer(signer_account_id: String) -> VMContext {
@@ -61,6 +64,14 @@ pub fn get_context_for_ft_transfer(signer_account_id: String) -> VMContext {
 }
 pub fn get_context_at_block(block_index: u64) -> VMContext {
     VMContextBuilder::new().block_index(block_index).is_view(true).build()
+}
+pub fn get_context_with_deposit_at_block(signer_account_id: String, block_index: u64) -> VMContext {
+    VMContextBuilder::new()
+        .signer_account_id(signer_account_id.parse().unwrap())
+        .is_view(false)
+        .attached_deposit(TEST_DEPOSIT_AMOUNT) // required for post_data_request()
+        .block_index(block_index)
+        .build()
 }
 
 pub fn generate_bn254_key() -> (PublicKey, PrivateKey) {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Because committees are selected a few epochs in advance to allow nodes to prepare, we need a bootstrapping mechanism to select the first few committees once there are enough active nodes.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Explicitly track `active_nodes` and `inactive_nodes` to make it easier to select committee members
- Created `process_epoch()` function, which does 2 things:
  1. Moves pending nodes from `inactive_nodes` to `active_nodes` once their activation epoch is reached
  2. Selects committee members for (current epoch + `EPOCH_COMMITTEES_LOOKAHEAD`). The contract is initialized with `bootstrapping_phase = true`, so once there are `VALIDATOR_COMMITTEE_SIZE` active nodes, it selects committees for multiple epochs and then sets bootstrapping_phase to false.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tests have been updated to call `process_epoch()` where `post_signed_batch()` is called. The `post_signed_batch()` test in `batch_test.rs` also checks to see if the bootstrapping creates 3 committees and that each committee has `SLOTS_PER_EPOCH` members.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
-->

Still need to implement:
- Only slot leader can call `post_signed_batch()`
- Restrictions on withdrawing while an active node or pending node
- Committee selection algorithm instead of round-robin

Optimizations are also welcome if you spot one :)
