### PR TITLE
Delegate CLI register, setup & stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4723,6 +4723,7 @@ dependencies = [
  "seda-crypto",
  "seda-runtime-sdk",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4711,13 +4711,18 @@ dependencies = [
 name = "seda-delegate-cli"
 version = "0.1.0"
 dependencies = [
+ "bn254",
+ "bs58",
  "clap",
  "clap-markdown",
  "clap_complete",
  "dotenv",
+ "hex",
  "seda-chains",
  "seda-config",
+ "seda-crypto",
  "seda-runtime-sdk",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,23 +48,23 @@ base64 = "0.13"
 bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
 borsh = { version = "0.9", default-features = false }
 clap = { version = "4.1", default-features = false }
-clap_complete = { version = "4.1", default-features = false }
 clap-markdown = { version = "0.1", default-features = false }
+clap_complete = { version = "4.1", default-features = false }
 concat-kdf = "0.1"
 dotenv = "0.15"
 ed25519-dalek = "1.0"
 futures = { version = "0.3", default-features = false }
 getrandom = { version = "0.2"}
 hex = "0.4"
-jsonrpsee-types = "0.16"
 jsonrpsee = { version = "0.16", default-features = false }
+jsonrpsee-types = "0.16"
 lazy_static = "1.4"
 libp2p = { version = "0.50", default-features = false }
 near-bigint = "1.0"
+near-contract-standards = "4.0"
 near-crypto = "0.15"
 near-jsonrpc-client = { version = "0.4", default-features = false }
 near-jsonrpc-primitives = "0.15"
-near-contract-standards = "4.0"
 near-primitives = "0.15"
 near-sdk = { version = "4.0", default-features = false }
 near-sys = "0.2"
@@ -76,6 +76,7 @@ rusqlite = { version = "0.28", features = ["bundled"] }
 schemars = "0.8"
 seda-chains = { path = "./chains" }
 seda-config = { path = "./config" }
+seda-crypto = { path = "./crypto" }
 seda-logger = { path = "./logger" }
 seda-node = { path = "./node" }
 seda-p2p = { path = "./p2p" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ opt-level = "z"
 [workspace.dependencies]
 actix = "0.13"
 async-trait = "0.1"
+bs58 = "0.4.0"
 base64 = "0.13"
 bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
 borsh = { version = "0.9", default-features = false }

--- a/chains/src/near_chain.rs
+++ b/chains/src/near_chain.rs
@@ -81,7 +81,6 @@ impl ChainAdapterTrait for NearChain {
     ) -> Result<Vec<u8>> {
         let client = JsonRpcClient::connect(server_url);
         let signer_account_id: AccountId = signer_acc_str.parse()?;
-
         let signer_secret_key: near_crypto::SecretKey = signer_sk_str.parse()?;
         let signer = near_crypto::InMemorySigner::from_secret_key(signer_account_id, signer_secret_key);
 

--- a/config/src/configs/delegate.rs
+++ b/config/src/configs/delegate.rs
@@ -28,6 +28,9 @@ pub struct PartialDelegateConfig {
     /// An option to override the RPC URL
     #[arg(long)]
     pub rpc_url:              Option<String>,
+    /// An option to override the node gas config value.
+    #[arg(short, long)]
+    pub gas:                  Option<u64>,
 }
 
 #[cfg(feature = "delegate-cli")]
@@ -49,6 +52,7 @@ impl PartialDelegateConfig {
 
         let delegate_contract_id = merge_config_cli!(self, cli_options, delegate_contract_id, Ok(String::new()))?;
         let rpc_url = merge_config_cli!(self, cli_options, rpc_url, Ok(DelegateConfigInner::RPC_URL.to_string()))?;
+        let gas = merge_config_cli!(self, cli_options, gas, Ok(DelegateConfigInner::GAS))?;
 
         Ok(Arc::new(DelegateConfigInner {
             validator_secret_key,
@@ -56,6 +60,7 @@ impl PartialDelegateConfig {
             signer_account_id,
             delegate_contract_id,
             rpc_url,
+            gas,
         }))
     }
 }
@@ -69,6 +74,7 @@ impl Config for PartialDelegateConfig {
             account_secret_key:   None,
             signer_account_id:    None,
             rpc_url:              None,
+            gas:                  Some(DelegateConfigInner::GAS),
         }
     }
 
@@ -86,6 +92,7 @@ pub struct DelegateConfigInner {
     pub signer_account_id:    String,
     pub delegate_contract_id: String,
     pub rpc_url:              String,
+    pub gas:                  u64,
 }
 
 impl DelegateConfigInner {
@@ -97,6 +104,7 @@ impl DelegateConfigInner {
             validator_secret_key: String::new(),
             account_secret_key:   String::new(),
             signer_account_id:    String::new(),
+            gas:                  Self::GAS,
         })
     }
 
@@ -107,6 +115,7 @@ impl DelegateConfigInner {
 }
 
 impl DelegateConfigInner {
+    pub const GAS: u64 = 300_000_000_000_000;
     pub const RPC_URL: &str = "https://rpc.testnet.near.org";
 }
 

--- a/config/src/configs/delegate.rs
+++ b/config/src/configs/delegate.rs
@@ -115,6 +115,7 @@ impl DelegateConfigInner {
 }
 
 impl DelegateConfigInner {
+    // 300 Tgas
     pub const GAS: u64 = 300_000_000_000_000;
     pub const RPC_URL: &str = "https://rpc.testnet.near.org";
 }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 bn254 = {workspace = true}
 concat-kdf = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true }
-hex = {workspace = true}
+hex = { workspace = true }
 rand = {version = "0.7"}
 sha2 = { workspace = true }
 thiserror = { workspace = true }

--- a/crypto/src/crypto_test.rs
+++ b/crypto/src/crypto_test.rs
@@ -5,7 +5,7 @@ use ed25519_dalek::{Keypair as Ed25519DalekKeyPair, SecretKey, Signature, Signer
 use rand::rngs::OsRng;
 use tokio::fs::write;
 
-use crate::{derive_bn254_key_pair, derive_ed25519_key_pair, Bn254KeyPair, Ed25519KeyPair};
+use crate::{derive_bn254_key_pair_from_fs, derive_ed25519_key_pair_from_fs, Bn254KeyPair, Ed25519KeyPair};
 
 const TEST_SK_PATH: &str = "./seda_test_sk";
 async fn generate_test_sk() {
@@ -21,7 +21,7 @@ async fn generate_test_sk() {
 #[tokio::test]
 async fn generate_bn254_pair() {
     generate_test_sk().await;
-    let bn_pair: Bn254KeyPair = derive_bn254_key_pair(TEST_SK_PATH, 1).expect("Couldn't derive bn254 key pair");
+    let bn_pair: Bn254KeyPair = derive_bn254_key_pair_from_fs(TEST_SK_PATH, 1).expect("Couldn't derive bn254 key pair");
     let msg = "awesome-seda";
     let signature = ECDSA::sign(msg, &bn_pair.private_key).expect("couldnt sign msg");
     assert!(ECDSA::verify(msg, &signature, &bn_pair.public_key).is_ok())
@@ -30,7 +30,8 @@ async fn generate_bn254_pair() {
 #[tokio::test]
 async fn generate_ed25519_pair() {
     generate_test_sk().await;
-    let ed_pair: Ed25519KeyPair = derive_ed25519_key_pair(TEST_SK_PATH, 1).expect("Couldn't derive ed25519 key pair");
+    let ed_pair: Ed25519KeyPair =
+        derive_ed25519_key_pair_from_fs(TEST_SK_PATH, 1).expect("Couldn't derive ed25519 key pair");
     let dalek_pair =
         Ed25519DalekKeyPair::from_bytes(&[ed_pair.private_key.to_bytes(), ed_pair.public_key.to_bytes()].concat())
             .expect("Couldn't convert ed25519 keypair");

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -13,33 +13,57 @@ pub enum KeyType {
 
 #[allow(dead_code)]
 pub struct Ed25519KeyPair {
-    public_key:  Ed25519PublicKey,
-    private_key: Ed25519PrivateKey,
-}
-#[allow(dead_code)]
-pub struct Bn254KeyPair {
-    public_key:  Bn254PublicKey,
-    private_key: Bn254PrivateKey,
+    pub public_key:  Ed25519PublicKey,
+    pub private_key: Ed25519PrivateKey,
 }
 
-pub fn derive_bn254_key_pair(sk_path: &str, index: usize) -> Result<Bn254KeyPair, CryptoError> {
+#[allow(dead_code)]
+pub struct Bn254KeyPair {
+    pub public_key:  Bn254PublicKey,
+    pub private_key: Bn254PrivateKey,
+}
+
+impl From<Ed25519KeyPair> for Vec<u8> {
+    fn from(val: Ed25519KeyPair) -> Self {
+        let mut result = vec![];
+
+        result.extend_from_slice(val.private_key.as_bytes());
+        result.extend_from_slice(val.public_key.as_bytes());
+
+        result
+    }
+}
+
+pub fn derive_bn254_key_pair_from_fs(sk_path: &str, index: usize) -> Result<Bn254KeyPair, CryptoError> {
     let seed = read_to_string(sk_path)?;
+
+    derive_bn254_key_pair(&seed, index)
+}
+
+pub fn derive_bn254_key_pair(seed: &str, index: usize) -> Result<Bn254KeyPair, CryptoError> {
     let master_sk = derive_key::<sha2::Sha256>(seed.as_bytes(), b"bn254", SECRET_KEY_LENGTH)?;
     let sk = derive_key::<sha2::Sha256>(master_sk.as_slice(), &index.to_ne_bytes(), SECRET_KEY_LENGTH)?;
     let private_key = Bn254PrivateKey::try_from(sk.as_slice()).unwrap();
     let public_key = Bn254PublicKey::from_private_key(&private_key);
+
     Ok(Bn254KeyPair {
         public_key,
         private_key,
     })
 }
 
-pub fn derive_ed25519_key_pair(sk_path: &str, index: usize) -> Result<Ed25519KeyPair, CryptoError> {
+pub fn derive_ed25519_key_pair_from_fs(sk_path: &str, index: usize) -> Result<Ed25519KeyPair, CryptoError> {
     let seed = read_to_string(sk_path)?;
+
+    derive_ed25519_key_pair(&seed, index)
+}
+
+pub fn derive_ed25519_key_pair(seed: &str, index: usize) -> Result<Ed25519KeyPair, CryptoError> {
     let master_sk = derive_key::<sha2::Sha256>(seed.as_bytes(), b"ed25519", SECRET_KEY_LENGTH)?;
     let sk = derive_key::<sha2::Sha256>(master_sk.as_slice(), &index.to_ne_bytes(), SECRET_KEY_LENGTH)?;
     let private_key = Ed25519PrivateKey::from_bytes(sk.as_slice()).unwrap();
     let public_key: Ed25519PublicKey = (&private_key).into();
+
     Ok(Ed25519KeyPair {
         public_key,
         private_key,

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -3,7 +3,7 @@ use std::fs::read_to_string;
 use bn254::{PrivateKey as Bn254PrivateKey, PublicKey as Bn254PublicKey};
 use concat_kdf::derive_key;
 use ed25519_dalek::{PublicKey as Ed25519PublicKey, SecretKey as Ed25519PrivateKey, SECRET_KEY_LENGTH};
-mod errors;
+pub mod errors;
 use crate::errors::CryptoError;
 #[derive(PartialEq)]
 pub enum KeyType {

--- a/delegate-cli/Cargo.toml
+++ b/delegate-cli/Cargo.toml
@@ -9,11 +9,16 @@ name = "seda-delegate"
 path = "src/main.rs"
 
 [dependencies]
+bn254 = { workspace = true }
+bs58 = "0.4.0"
 clap = { workspace = true, features = ["default"] }
 clap-markdown = { workspace = true }
 clap_complete = { workspace = true }
 dotenv = { workspace = true }
+hex = "0.4"
 seda-chains = { workspace = true }
-seda-config = { workspace = true, features = ["cli", "delegate-cli"]}
+seda-config = { workspace = true, features = ["cli", "delegate-cli"] }
+seda-crypto = { workspace = true }
 seda-runtime-sdk = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true }

--- a/delegate-cli/Cargo.toml
+++ b/delegate-cli/Cargo.toml
@@ -10,15 +10,16 @@ path = "src/main.rs"
 
 [dependencies]
 bn254 = { workspace = true }
-bs58 = "0.4.0"
+bs58 = { workspace = true }
 clap = { workspace = true, features = ["default"] }
 clap-markdown = { workspace = true }
 clap_complete = { workspace = true }
 dotenv = { workspace = true }
-hex = "0.4"
+hex = { workspace = true }
 seda-chains = { workspace = true }
 seda-config = { workspace = true, features = ["cli", "delegate-cli"] }
 seda-crypto = { workspace = true }
 seda-runtime-sdk = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true }
+thiserror = { workspace = true }

--- a/delegate-cli/src/cli/commands/mod.rs
+++ b/delegate-cli/src/cli/commands/mod.rs
@@ -1,2 +1,4 @@
 pub mod register;
+pub mod setup;
+pub mod stake;
 pub mod top_up;

--- a/delegate-cli/src/cli/commands/mod.rs
+++ b/delegate-cli/src/cli/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod register;
 pub mod top_up;

--- a/delegate-cli/src/cli/commands/register.rs
+++ b/delegate-cli/src/cli/commands/register.rs
@@ -1,0 +1,86 @@
+use bn254::ECDSA;
+use clap::Args;
+use seda_chains::{chain, Client};
+use seda_config::{ChainConfigsInner, DelegateConfig};
+use seda_crypto::{derive_bn254_key_pair, derive_ed25519_key_pair};
+use seda_runtime_sdk::{Chain, ToBytes};
+use serde_json::json;
+
+use crate::cli::utils::to_yocto;
+
+#[derive(Debug, Args)]
+pub struct Register {
+    /// The contract address to register on
+    pub delegation_contract_id: String,
+    /// The multi address that is associated with the node
+    pub multi_addr:             Option<String>,
+}
+
+impl Register {
+    pub async fn handle(self, config: DelegateConfig) {
+        dbg!(&config.validator_secret_key);
+        let bn254_key = derive_bn254_key_pair(&config.validator_secret_key, 0).unwrap();
+        let ed25519_key = derive_ed25519_key_pair(&config.validator_secret_key, 0).unwrap();
+        let signature = ECDSA::sign(ed25519_key.public_key, &bn254_key.private_key).unwrap();
+
+        // https://docs.near.org/concepts/basics/accounts/creating-accounts#local-implicit-account
+
+        // TODO: Make construct_signed_tx only accept bytes and not strings
+        let ed25519_public_key = ed25519_key.public_key.as_bytes().to_vec();
+        let ed25519_secret_key_bytes: Vec<u8> = ed25519_key.into();
+
+        dbg!(&hex::encode(&ed25519_public_key));
+
+        let signed_tx = chain::construct_signed_tx(
+            Chain::Near,
+            &hex::encode(&ed25519_public_key),
+            &bs58::encode(ed25519_secret_key_bytes).into_string(),
+            &self.delegation_contract_id,
+            "register_node",
+            json!({
+                "multi_addr": self.multi_addr.unwrap_or(String::new()),
+                "bn254_public_key": &ed25519_public_key,
+                "signature": &signature.to_compressed().unwrap(),
+            })
+            .to_string()
+            .into_bytes(),
+            1,
+            1000,
+            &config.rpc_url,
+        )
+        .await
+        .unwrap();
+
+        println!(
+            "Registring {} on contract {}..",
+            &hex::encode(&ed25519_public_key),
+            self.delegation_contract_id
+        );
+
+        let config = ChainConfigsInner::test_config();
+        let client = Client::new(&Chain::Near, &config).unwrap();
+        chain::send_tx(Chain::Near, client, &signed_tx).await.unwrap();
+
+        println!("Transaction has been completed");
+
+        // let amount_yocto = to_yocto(&self.amount);
+
+        // let signed_tx = chain::construct_transfer_tx(
+        //     Chain::Near,
+        //     &config.signer_account_id,
+        //     &config.account_secret_key,
+        //     &self.receiver,
+        //     amount_yocto,
+        //     &config.rpc_url,
+        // )
+        // .await
+        // .unwrap();
+
+        // let config = ChainConfigsInner::test_config();
+        // let client = Client::new(&Chain::Near, &config).unwrap();
+
+        // println!("Sending {}N to {}..", self.amount, self.receiver);
+        // chain::send_tx(Chain::Near, client, &signed_tx).await.unwrap();
+        // println!("Transaction has been completed");
+    }
+}

--- a/delegate-cli/src/cli/commands/register.rs
+++ b/delegate-cli/src/cli/commands/register.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use seda_chains::{chain, Client};
 use seda_config::{ChainConfigsInner, DelegateConfig};
 use seda_crypto::{derive_bn254_key_pair, derive_ed25519_key_pair};
-use seda_runtime_sdk::{Chain, ToBytes};
+use seda_runtime_sdk::Chain;
 use serde_json::json;
 
 use crate::cli::utils::to_yocto;
@@ -18,34 +18,29 @@ pub struct Register {
 
 impl Register {
     pub async fn handle(self, config: DelegateConfig) {
-        dbg!(&config.validator_secret_key);
         let bn254_key = derive_bn254_key_pair(&config.validator_secret_key, 0).unwrap();
         let ed25519_key = derive_ed25519_key_pair(&config.validator_secret_key, 0).unwrap();
-        let signature = ECDSA::sign(ed25519_key.public_key, &bn254_key.private_key).unwrap();
-
-        // https://docs.near.org/concepts/basics/accounts/creating-accounts#local-implicit-account
-
-        // TODO: Make construct_signed_tx only accept bytes and not strings
         let ed25519_public_key = ed25519_key.public_key.as_bytes().to_vec();
+        let account_id = hex::encode(&ed25519_public_key);
+        let signature = ECDSA::sign(&account_id, &bn254_key.private_key).unwrap();
         let ed25519_secret_key_bytes: Vec<u8> = ed25519_key.into();
 
-        dbg!(&hex::encode(&ed25519_public_key));
-
+        // TODO: Make construct_signed_tx only accept bytes and not strings
         let signed_tx = chain::construct_signed_tx(
             Chain::Near,
-            &hex::encode(&ed25519_public_key),
+            &account_id,
             &bs58::encode(ed25519_secret_key_bytes).into_string(),
             &self.delegation_contract_id,
             "register_node",
             json!({
                 "multi_addr": self.multi_addr.unwrap_or(String::new()),
-                "bn254_public_key": &ed25519_public_key,
+                "bn254_public_key": &bn254_key.public_key.to_compressed().unwrap(),
                 "signature": &signature.to_compressed().unwrap(),
             })
             .to_string()
             .into_bytes(),
-            1,
-            1000,
+            80000000000000,
+            to_yocto("0.01"),
             &config.rpc_url,
         )
         .await
@@ -62,25 +57,5 @@ impl Register {
         chain::send_tx(Chain::Near, client, &signed_tx).await.unwrap();
 
         println!("Transaction has been completed");
-
-        // let amount_yocto = to_yocto(&self.amount);
-
-        // let signed_tx = chain::construct_transfer_tx(
-        //     Chain::Near,
-        //     &config.signer_account_id,
-        //     &config.account_secret_key,
-        //     &self.receiver,
-        //     amount_yocto,
-        //     &config.rpc_url,
-        // )
-        // .await
-        // .unwrap();
-
-        // let config = ChainConfigsInner::test_config();
-        // let client = Client::new(&Chain::Near, &config).unwrap();
-
-        // println!("Sending {}N to {}..", self.amount, self.receiver);
-        // chain::send_tx(Chain::Near, client, &signed_tx).await.unwrap();
-        // println!("Transaction has been completed");
     }
 }

--- a/delegate-cli/src/cli/commands/setup.rs
+++ b/delegate-cli/src/cli/commands/setup.rs
@@ -3,43 +3,52 @@ use seda_config::DelegateConfig;
 use seda_crypto::derive_ed25519_key_pair;
 
 use super::{register::Register, stake::Stake, top_up::TopUp};
+use crate::cli::errors::Result;
 
 #[derive(Debug, Args)]
 pub struct Setup {
     /// The contract address to stake on
     pub delegation_contract_id: String,
-    /// Amount of tokens to transfer in wholes (1 = 1 NEAR) (defaults to 5 NEAR)
-    pub topup_amount:           Option<String>,
-    /// The amount of SEDA tokens to stake (1 = 1 SEDA) (defaults to 32 SEDA)
-    pub stake_amount:           Option<String>,
+
+    #[clap(default_value_t = 5, short, long)]
+    /// Amount of tokens to transfer in wholes (1 = 1 NEAR)
+    pub topup_amount: u64,
+
+    #[clap(default_value_t = 32, short, long)]
+    /// The amount of SEDA tokens to stake (1 = 1 SEDA)
+    pub stake_amount: u64,
+
+    #[clap(default_value = "", short, long)]
     /// The multi address that is associated with the node (defaults to none)
-    pub multi_addr:             Option<String>,
+    pub multi_addr: String,
 }
 
 impl Setup {
-    pub async fn handle(self, config: DelegateConfig) {
+    pub async fn handle(self, config: DelegateConfig) -> Result<()> {
         let ed25519_key = derive_ed25519_key_pair(&config.validator_secret_key, 0).unwrap();
         let ed25519_public_key = ed25519_key.public_key.as_bytes().to_vec();
 
         let top_up = TopUp {
-            amount:   self.topup_amount.unwrap_or("5".to_string()),
+            amount:   self.topup_amount,
             receiver: hex::encode(&ed25519_public_key),
         };
 
-        top_up.handle(config.clone()).await;
+        top_up.handle(config.clone()).await?;
 
         let register = Register {
             delegation_contract_id: self.delegation_contract_id.clone(),
             multi_addr:             self.multi_addr,
         };
 
-        register.handle(config.clone()).await;
+        register.handle(config.clone()).await?;
 
         let stake = Stake {
-            amount:                 self.stake_amount.unwrap_or("32".to_string()),
+            amount:                 self.stake_amount,
             delegation_contract_id: self.delegation_contract_id,
         };
 
-        stake.handle(config).await;
+        stake.handle(config).await?;
+
+        Ok(())
     }
 }

--- a/delegate-cli/src/cli/commands/setup.rs
+++ b/delegate-cli/src/cli/commands/setup.rs
@@ -1,0 +1,45 @@
+use clap::Args;
+use seda_config::DelegateConfig;
+use seda_crypto::derive_ed25519_key_pair;
+
+use super::{register::Register, stake::Stake, top_up::TopUp};
+
+#[derive(Debug, Args)]
+pub struct Setup {
+    /// The contract address to stake on
+    pub delegation_contract_id: String,
+    /// Amount of tokens to transfer in wholes (1 = 1 NEAR) (defaults to 5 NEAR)
+    pub topup_amount:           Option<String>,
+    /// The amount of SEDA tokens to stake (1 = 1 SEDA) (defaults to 32 SEDA)
+    pub stake_amount:           Option<String>,
+    /// The multi address that is associated with the node (defaults to none)
+    pub multi_addr:             Option<String>,
+}
+
+impl Setup {
+    pub async fn handle(self, config: DelegateConfig) {
+        let ed25519_key = derive_ed25519_key_pair(&config.validator_secret_key, 0).unwrap();
+        let ed25519_public_key = ed25519_key.public_key.as_bytes().to_vec();
+
+        let top_up = TopUp {
+            amount:   self.topup_amount.unwrap_or("5".to_string()),
+            receiver: hex::encode(&ed25519_public_key),
+        };
+
+        top_up.handle(config.clone()).await;
+
+        let register = Register {
+            delegation_contract_id: self.delegation_contract_id.clone(),
+            multi_addr:             self.multi_addr,
+        };
+
+        register.handle(config.clone()).await;
+
+        let stake = Stake {
+            amount:                 self.stake_amount.unwrap_or("32".to_string()),
+            delegation_contract_id: self.delegation_contract_id,
+        };
+
+        stake.handle(config).await;
+    }
+}

--- a/delegate-cli/src/cli/commands/stake.rs
+++ b/delegate-cli/src/cli/commands/stake.rs
@@ -1,0 +1,58 @@
+use clap::Args;
+use seda_chains::{chain, Client};
+use seda_config::{ChainConfigsInner, DelegateConfig};
+use seda_crypto::derive_ed25519_key_pair;
+use seda_runtime_sdk::Chain;
+use serde_json::json;
+
+use crate::cli::utils::to_yocto;
+
+#[derive(Debug, Args)]
+pub struct Stake {
+    /// The contract address to stake on
+    pub delegation_contract_id: String,
+    /// The amount of SEDA tokens to stake (1 = 1 SEDA)
+    pub amount:                 String,
+}
+
+impl Stake {
+    pub async fn handle(self, config: DelegateConfig) {
+        // SEDA tokens are in the same denominator as NEAR (24 decimals)
+        let amount_yocto = to_yocto(&self.amount);
+        let ed25519_key = derive_ed25519_key_pair(&config.validator_secret_key, 0).unwrap();
+        let mut ed25519_public_key: Vec<u8> = vec![0];
+        ed25519_public_key.extend_from_slice(ed25519_key.public_key.as_bytes());
+
+        let account_id = hex::encode(&ed25519_public_key);
+
+        println!(
+            "Staking {} SEDA on {} for node {account_id}..",
+            &self.amount, self.delegation_contract_id
+        );
+
+        let signed_tx = chain::construct_signed_tx(
+            Chain::Near,
+            &config.signer_account_id,
+            &config.account_secret_key,
+            &self.delegation_contract_id,
+            "deposit",
+            json!({
+                "amount": &amount_yocto.to_string(),
+                "ed25519_public_key": &ed25519_public_key,
+            })
+            .to_string()
+            .into_bytes(),
+            config.gas,
+            to_yocto("0.01"),
+            &config.rpc_url,
+        )
+        .await
+        .unwrap();
+
+        let config = ChainConfigsInner::test_config();
+        let client = Client::new(&Chain::Near, &config).unwrap();
+        chain::send_tx(Chain::Near, client, &signed_tx).await.unwrap();
+
+        println!("Transaction has been completed");
+    }
+}

--- a/delegate-cli/src/cli/commands/top_up.rs
+++ b/delegate-cli/src/cli/commands/top_up.rs
@@ -3,20 +3,20 @@ use seda_chains::{chain, Client};
 use seda_config::{ChainConfigsInner, DelegateConfig};
 use seda_runtime_sdk::Chain;
 
-use crate::cli::utils::to_yocto;
+use crate::cli::{errors::Result, utils::to_yocto};
 
 #[derive(Debug, Args)]
 pub struct TopUp {
     /// The receiver account id you want to transfer to (ex. example.near)
     pub receiver: String,
     /// Amount of tokens to transfer in wholes (1 = 1 NEAR)
-    pub amount:   String,
+    pub amount:   u64,
 }
 
 impl TopUp {
-    pub async fn handle(self, config: DelegateConfig) {
+    pub async fn handle(self, config: DelegateConfig) -> Result<()> {
         // Convert to yocto NEAR, which uses 24 decimals
-        let amount_yocto = to_yocto(&self.amount);
+        let amount_yocto = to_yocto(&self.amount.to_string());
 
         let signed_tx = chain::construct_transfer_tx(
             Chain::Near,
@@ -26,14 +26,15 @@ impl TopUp {
             amount_yocto,
             &config.rpc_url,
         )
-        .await
-        .unwrap();
+        .await?;
 
         let config = ChainConfigsInner::test_config();
-        let client = Client::new(&Chain::Near, &config).unwrap();
+        let client = Client::new(&Chain::Near, &config)?;
 
         println!("Sending {}N to {}..", self.amount, self.receiver);
-        chain::send_tx(Chain::Near, client, &signed_tx).await.unwrap();
+        chain::send_tx(Chain::Near, client, &signed_tx).await?;
         println!("Transaction has been completed");
+
+        Ok(())
     }
 }

--- a/delegate-cli/src/cli/errors.rs
+++ b/delegate-cli/src/cli/errors.rs
@@ -1,0 +1,18 @@
+use bn254::Error as Bn254Error;
+use seda_chains::ChainAdapterError;
+use seda_crypto::errors::CryptoError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DelegateCliError {
+    #[error("Could not convert key: {0}")]
+    Crypto(#[from] CryptoError),
+
+    #[error("BN254 operation failed: {0}")]
+    Bn254(#[from] Bn254Error),
+
+    #[error("Using the chain interface threw an error: {0}")]
+    Chain(#[from] ChainAdapterError),
+}
+
+pub type Result<T, E = DelegateCliError> = core::result::Result<T, E>;

--- a/delegate-cli/src/cli/mod.rs
+++ b/delegate-cli/src/cli/mod.rs
@@ -1,7 +1,10 @@
 use clap::{command, Parser, Subcommand};
 use seda_config::{DelegateConfig, PartialDelegateConfig};
+
+use self::errors::Result;
 mod commands;
 
+pub mod errors;
 mod utils;
 
 #[derive(Parser)]
@@ -32,20 +35,22 @@ pub enum Command {
 
 impl Command {
     #[tokio::main]
-    pub async fn handle(self, config: DelegateConfig) {
+    pub async fn handle(self, config: DelegateConfig) -> Result<()> {
         match self {
             Self::TopUp(top_up) => {
-                top_up.handle(config).await;
+                top_up.handle(config).await?;
             }
             Self::Register(register) => {
-                register.handle(config).await;
+                register.handle(config).await?;
             }
             Self::Stake(stake) => {
-                stake.handle(config).await;
+                stake.handle(config).await?;
             }
             Self::Setup(setup) => {
-                setup.handle(config).await;
+                setup.handle(config).await?;
             }
         }
+
+        Ok(())
     }
 }

--- a/delegate-cli/src/cli/mod.rs
+++ b/delegate-cli/src/cli/mod.rs
@@ -22,6 +22,8 @@ pub struct CliOptions {
 pub enum Command {
     /// Top-up a target account by a given amount in NEAR
     TopUp(commands::top_up::TopUp),
+    /// Register a node to a delegation contract
+    Register(commands::register::Register),
 }
 
 impl Command {
@@ -30,6 +32,9 @@ impl Command {
         match self {
             Self::TopUp(top_up) => {
                 top_up.handle(config).await;
+            }
+            Self::Register(register) => {
+                register.handle(config).await;
             }
         }
     }

--- a/delegate-cli/src/cli/mod.rs
+++ b/delegate-cli/src/cli/mod.rs
@@ -24,6 +24,10 @@ pub enum Command {
     TopUp(commands::top_up::TopUp),
     /// Register a node to a delegation contract
     Register(commands::register::Register),
+    /// Allows you to stake to a given delegator
+    Stake(commands::stake::Stake),
+    /// A all in one command to get started as a node operator
+    Setup(commands::setup::Setup),
 }
 
 impl Command {
@@ -35,6 +39,12 @@ impl Command {
             }
             Self::Register(register) => {
                 register.handle(config).await;
+            }
+            Self::Stake(stake) => {
+                stake.handle(config).await;
+            }
+            Self::Setup(setup) => {
+                setup.handle(config).await;
             }
         }
     }

--- a/delegate-cli/src/main.rs
+++ b/delegate-cli/src/main.rs
@@ -1,11 +1,12 @@
 use clap::Parser;
+use cli::errors::Result;
 use seda_config::{Config, PartialDelegateConfig};
 
 use crate::cli::CliOptions;
 
 mod cli;
 
-fn main() {
+fn main() -> Result<()> {
     // Load the dotenv file first since our config overloads values from it.
     dotenv::dotenv().ok();
 
@@ -15,5 +16,5 @@ fn main() {
 
     let config = options.delegate_config.to_config(env_config).unwrap();
 
-    options.command.handle(config);
+    options.command.handle(config)
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Have a CLI tool where a user can register, stake and top-up a validator node.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* Add a new project to the workspace "delegate-cli"
* Implement stake `seda-delegate stake <DELEGATION_CONTRACT_ID> <AMOUNT>`
* Implement register `seda-delegate register <DELEGATION_CONTRACT_ID> [MULTI_ADDR]`
* Implement setup `seda-delegate setup <DELEGATION_CONTRACT_ID> [TOPUP_AMOUNT] [STAKE_AMOUNT] [MULTI_ADDR]`

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Create a `.env` file where the following variables exist:

```
# secret key that is generated by the node itself (seda_key)
VALIDATOR_SECRET_KEY = "FILL_ME_IN"

# The NEAR ed25519 account secret key that holds the SEDA/NEAR tokens
ACCOUNT_SECRET_KEY = "ed25519:FILL_ME_IN"

# The NEAR account id that holds the SEDA/NEAR tokens (and are from the secret key)
SIGNER_ACCOUNT_ID = "FILL_ME_IN.near"
```

Then you can run one of the above mentioned commands