### PR TITLE
Refactor/post signed batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,9 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
 
 [[package]]
 name = "unicode-ident"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 bn254 = { workspace = true }
-bs58 = "0.4.0"
+bs58 = { workspace = true }
 getrandom = { workspace = true, features = ["custom"], default-features = false}
 rand = {workspace = true, features = ["std"], default-features = false }
 hex = { workspace = true }

--- a/contracts/src/batch_test.rs
+++ b/contracts/src/batch_test.rs
@@ -1,5 +1,9 @@
+use std::collections::HashMap;
+
+use bn254::{PrivateKey, PublicKey};
 use near_contract_standards::{fungible_token::core::FungibleTokenCore, storage_management::StorageManagement};
-use near_sdk::{json_types::U128, testing_env};
+use near_sdk::{env, json_types::U128, testing_env, AccountId};
+use rand::Rng;
 
 use super::test_utils::{
     bn254_sign,
@@ -9,54 +13,54 @@ use super::test_utils::{
     get_context_with_deposit_at_block,
     new_contract,
 };
-use crate::{consts::INIT_MINIMUM_STAKE, tests::test_utils::make_test_account};
+use crate::{
+    consts::INIT_MINIMUM_STAKE,
+    tests::test_utils::{generate_bn254_key, make_test_account},
+};
 
 #[test]
 fn post_signed_batch() {
     let mut contract = new_contract();
     let dao = make_test_account("dao_near".to_string());
-    let alice = make_test_account("alice_near".to_string());
-    let bob = make_test_account("bob_near".to_string());
+
     let deposit_amount = U128(INIT_MINIMUM_STAKE);
+    let test_acc = make_test_account("test_near".to_string());
 
     // post some data requests to the accumulator
-    testing_env!(get_context_with_deposit(bob.clone()));
+    testing_env!(get_context_with_deposit(test_acc.clone()));
     contract.post_data_request("data_request_1".to_string());
     contract.post_data_request("data_request_2".to_string());
     contract.post_data_request("data_request_3".to_string());
 
-    // transfer some tokens to alice and bob
-    testing_env!(get_context_with_deposit(dao.clone()));
-    contract.storage_deposit(Some("alice_near".to_string().try_into().unwrap()), None);
-    contract.storage_deposit(Some("bob_near".to_string().try_into().unwrap()), None);
-    testing_env!(get_context_for_ft_transfer(dao));
-    contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
-    contract.ft_transfer("bob_near".to_string().try_into().unwrap(), deposit_amount, None);
+    let mut test_accounts: HashMap<AccountId, (PublicKey, PrivateKey)> = HashMap::new();
+    let num_of_nodes = 20;
+    for x in 0..num_of_nodes {
+        let acc_str = format!("{x:}_near");
+        let acc = make_test_account(acc_str.clone());
 
-    // register nodes for alice and bob
-    let alice_signature = bn254_sign(alice.clone(), "alice_near".to_string().as_bytes());
-    let bob_signature = bn254_sign(bob.clone(), "bob_near".to_string().as_bytes());
-    testing_env!(get_context_with_deposit(bob.clone()));
-    contract.register_node(
-        "0.0.0.0:8080".to_string(),
-        bob.clone().bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
-    );
-    testing_env!(get_context_with_deposit(alice.clone()));
-    contract.register_node(
-        "1.1.1.1:8080".to_string(),
-        alice.clone().bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
-    );
+        // transfer some tokens
+        testing_env!(get_context_with_deposit(dao.clone(),));
+        contract.storage_deposit(Some(acc_str.clone().try_into().unwrap()), None);
+        testing_env!(get_context_for_ft_transfer(dao.clone()));
+        contract.ft_transfer(acc_str.clone().try_into().unwrap(), deposit_amount, None);
 
-    // alice and bob deposit into contract
-    testing_env!(get_context_with_deposit(alice.clone()));
-    contract.deposit(deposit_amount, alice.clone().ed25519_public_key.into_bytes());
-    testing_env!(get_context_with_deposit(bob.clone()));
-    contract.deposit(deposit_amount, bob.clone().ed25519_public_key.into_bytes());
+        let (pk, sk) = generate_bn254_key();
+        test_accounts.insert(acc_str.parse().unwrap(), (pk, sk.clone()));
+        let sig = bn254_sign(&sk.clone(), acc_str.as_bytes());
+        testing_env!(get_context_with_deposit(acc.clone()));
+        // register nodes
+        contract.register_node(
+            "0.0.0.0:8080".to_string(),
+            pk.to_compressed().unwrap(),
+            sig.to_compressed().unwrap(),
+        );
+        // deposit into contract
+        testing_env!(get_context_with_deposit(acc.clone()));
+        contract.deposit(deposit_amount, acc.ed25519_public_key.clone().into());
+    }
 
     // time travel and activate nodes
-    testing_env!(get_context_with_deposit_at_block(bob.clone(), 1000000));
+    testing_env!(get_context_with_deposit_at_block(test_acc.clone(), 1000000));
     contract.process_epoch();
 
     // assert we have committees for this epoch and the next 2
@@ -70,24 +74,139 @@ fn post_signed_batch() {
 
     // get the merkle root (for all nodes to sign)
     let merkle_root = contract.compute_merkle_root();
+    let chosen_committee = contract.get_committees().first().unwrap().clone();
+    let (pk, sk) = &test_accounts.get(chosen_committee.first().unwrap()).unwrap();
+    let acc_merkle_root_signature = bn254_sign(&sk, &merkle_root);
 
-    // alice and bob sign the merkle root
-    let alice_merkle_root_signature = bn254_sign(alice.clone(), &merkle_root);
-    let bob_merkle_root_signature = bn254_sign(bob.clone(), &merkle_root);
+    let mut agg_public_key = pk.clone();
+    let mut agg_signature = acc_merkle_root_signature;
+    for index in chosen_committee.iter().skip(1) {
+        let (pk, sk) = &test_accounts.get(index).unwrap();
+        let acc_merkle_root_signature = bn254_sign(&sk, &merkle_root);
+        agg_public_key = agg_public_key + pk.clone();
+        agg_signature = agg_signature + acc_merkle_root_signature;
+    }
+    assert_eq!(contract.num_batches, 0);
+    for index in 0..num_of_nodes {
+        let acc_str = format!("{index:}_near");
+        let acc = make_test_account(acc_str);
 
-    // aggregate the signatures
-    let agg_public_key = alice.clone().bn254_public_key + bob.clone().bn254_public_key;
-    let agg_signature = alice_merkle_root_signature + bob_merkle_root_signature;
+        testing_env!(get_context_for_post_signed_batch(acc.clone()));
+        let slot_leader = contract.get_current_slot_leader();
 
-    // alice posts the signed batch
-    testing_env!(get_context_for_post_signed_batch(alice.clone()));
-    contract.post_signed_batch(
-        agg_signature.to_compressed().unwrap(),
-        agg_public_key.to_compressed().unwrap(),
-        [
-            "alice_near".to_string().try_into().unwrap(),
-            "bob_near".to_string().try_into().unwrap(),
-        ]
-        .to_vec(),
-    )
+        if slot_leader == acc.account_id.clone() {
+            let last_generated_random = contract.last_generated_random_number;
+            let leader_sig = bn254_sign(
+                &test_accounts.get(&acc.account_id).unwrap().1,
+                &last_generated_random.to_le_bytes(),
+            );
+            contract.post_signed_batch(
+                agg_signature.to_compressed().unwrap(),
+                agg_public_key.to_compressed().unwrap(),
+                chosen_committee.clone(),
+                leader_sig.to_compressed().unwrap(),
+            );
+            assert_ne!(last_generated_random, contract.last_generated_random_number);
+            assert_eq!(contract.num_batches, 1);
+
+            break;
+        }
+    }
+}
+
+#[test]
+#[should_panic(expected = "Invalid slot leader signature")]
+fn post_signed_batch_with_wrong_leader_sig() {
+    let mut contract = new_contract();
+    let deposit_amount = U128(INIT_MINIMUM_STAKE);
+    let dao = make_test_account("dao_near".to_string());
+
+    let test_acc = make_test_account("test_near".to_string());
+
+    // post some data requests to the accumulator
+    testing_env!(get_context_with_deposit(test_acc.clone()));
+    contract.post_data_request("data_request_1".to_string());
+    contract.post_data_request("data_request_2".to_string());
+    contract.post_data_request("data_request_3".to_string());
+
+    let mut test_accounts: HashMap<AccountId, (PublicKey, PrivateKey)> = HashMap::new();
+    let num_of_nodes = 20;
+    for x in 0..num_of_nodes {
+        let acc_str = format!("{x:}_near");
+        let acc = make_test_account(acc_str.clone());
+        // transfer some tokens
+        testing_env!(get_context_with_deposit(dao.clone(),));
+        contract.storage_deposit(Some(acc_str.clone().try_into().unwrap()), None);
+        testing_env!(get_context_for_ft_transfer(dao.clone()));
+        contract.ft_transfer(acc_str.clone().try_into().unwrap(), deposit_amount, None);
+
+        let (pk, sk) = generate_bn254_key();
+        test_accounts.insert(acc_str.parse().unwrap(), (pk, sk.clone()));
+        let sig = bn254_sign(&sk.clone(), acc_str.as_bytes());
+        testing_env!(get_context_with_deposit(acc.clone()));
+        // register nodes
+        contract.register_node(
+            "0.0.0.0:8080".to_string(),
+            pk.to_compressed().unwrap(),
+            sig.to_compressed().unwrap(),
+        );
+        // deposit into contract
+        testing_env!(get_context_with_deposit(acc.clone()));
+        contract.deposit(deposit_amount, acc.ed25519_public_key.clone().into());
+    }
+
+    // time travel and activate nodes
+    testing_env!(get_context_with_deposit_at_block(test_acc, 1000000));
+    contract.process_epoch();
+
+    // assert we have committees for this epoch and the next 2
+    assert_eq!(contract.get_committees().len(), 3);
+
+    // assert each committee has config.committee_size members
+    contract
+        .get_committees()
+        .into_iter()
+        .for_each(|comittee| assert_eq!(comittee.len() as u64, contract.config.committee_size));
+
+    // get the merkle root (for all nodes to sign)
+    let merkle_root = contract.compute_merkle_root();
+    let chosen_committee = contract.get_committees().first().unwrap().clone();
+    let (pk, sk) = &test_accounts.get(chosen_committee.first().unwrap()).unwrap();
+    let acc_merkle_root_signature = bn254_sign(&sk, &merkle_root);
+
+    let mut agg_public_key = pk.clone();
+    let mut agg_signature = acc_merkle_root_signature;
+    for index in chosen_committee.iter().skip(1) {
+        let (pk, sk) = &test_accounts.get(index).unwrap();
+        let acc_merkle_root_signature = bn254_sign(&sk, &merkle_root);
+        agg_public_key = agg_public_key + pk.clone();
+        agg_signature = agg_signature + acc_merkle_root_signature;
+    }
+    assert_eq!(contract.num_batches, 0);
+    for index in 0..num_of_nodes {
+        let acc_str = format!("{index:}_near");
+        let acc = make_test_account(acc_str);
+        testing_env!(get_context_for_post_signed_batch(acc.clone()));
+        let slot_leader = contract.get_current_slot_leader();
+
+        if slot_leader == acc.account_id.clone() {
+            let last_generated_random = contract.last_generated_random_number;
+            let mut rng = rand::thread_rng();
+            let random_seed = rng.gen::<u64>();
+            let invalid_leader_sig = bn254_sign(
+                &test_accounts.get(&acc.account_id.clone()).unwrap().1,
+                &random_seed.to_le_bytes(),
+            );
+            contract.post_signed_batch(
+                agg_signature.to_compressed().unwrap(),
+                agg_public_key.to_compressed().unwrap(),
+                chosen_committee.clone(),
+                invalid_leader_sig.to_compressed().unwrap(),
+            );
+            assert_ne!(last_generated_random, contract.last_generated_random_number);
+            assert_eq!(contract.num_batches, 1);
+
+            break;
+        }
+    }
 }

--- a/contracts/src/committee.rs
+++ b/contracts/src/committee.rs
@@ -48,6 +48,10 @@ impl MainchainContract {
         self.committees.clone()
     }
 
+    pub fn get_last_generated_random_number(&self) -> near_bigint::U256 {
+        self.last_generated_random_number
+    }
+
     pub fn get_current_slot_leader(&self) -> AccountId {
         let current_committee = self.committees.first().expect("Couldn't fetch current committee");
         let hash = Sha256::digest(

--- a/contracts/src/committee.rs
+++ b/contracts/src/committee.rs
@@ -7,7 +7,7 @@ register_custom_getrandom!(get_random_in_near);
 
 /// Contract private methods
 impl MainchainContract {
-    pub fn select_committee(&mut self, random_number: u64) -> Vec<AccountId> {
+    pub fn select_committee(&mut self, random_number: near_bigint::U256) -> Vec<AccountId> {
         let validators = self.active_nodes.keys_as_vector().to_vec();
         let mut chosen_committee: Vec<AccountId> = Vec::new();
         let mut chosen_indices: Vec<usize> = Vec::new();
@@ -59,7 +59,6 @@ impl MainchainContract {
         );
         let prn: near_bigint::U256 = near_bigint::U256::from_little_endian(&hash);
         let chosen_index = (prn % self.config.committee_size).as_usize();
-
         current_committee
             .get(chosen_index)
             .expect("Couldn't fetch chosen validator")

--- a/contracts/src/committee_selection_test.rs
+++ b/contracts/src/committee_selection_test.rs
@@ -17,22 +17,25 @@ fn test_committee_selection() {
     let mut contract = new_contract();
     let dao = make_test_account("dao_near".to_string());
     let bob = make_test_account("bob_near".to_string());
-    let deposit_amount = U128(INIT_MINIMUM_STAKE);
 
-    for x in 1..200 {
-        let acc = make_test_account(format!("{x:}_near"));
-        let signature = bn254_sign(acc.clone(), acc.account_id.as_bytes());
-        testing_env!(get_context_with_deposit(dao.clone()));
-        contract.storage_deposit(Some(acc.clone().account_id.try_into().unwrap()), None);
+    let deposit_amount = U128(INIT_MINIMUM_STAKE);
+    let num_of_nodes = 20;
+    for x in 1..num_of_nodes {
+        let acc_str = format!("{x:}_near");
+        let acc = make_test_account(acc_str.clone());
+
+        let sig = bn254_sign(&acc.bn254_private_key, acc_str.as_bytes());
+        testing_env!(get_context_with_deposit(dao.clone(),));
+        contract.storage_deposit(Some(acc_str.clone().try_into().unwrap()), None);
         testing_env!(get_context_for_ft_transfer(dao.clone()));
-        contract.ft_transfer(acc.clone().account_id.try_into().unwrap(), deposit_amount, None);
+        contract.ft_transfer(acc_str.clone().try_into().unwrap(), deposit_amount, None);
 
         // register node
         testing_env!(get_context_with_deposit(acc.clone()));
         contract.register_node(
             "0.0.0.0:8080".to_string(),
             acc.bn254_public_key.to_compressed().unwrap(),
-            signature.to_compressed().unwrap(),
+            sig.to_compressed().unwrap(),
         );
         testing_env!(get_context_with_deposit(acc.clone()));
         contract.deposit(deposit_amount, acc.ed25519_public_key.into_bytes());

--- a/contracts/src/data_request.rs
+++ b/contracts/src/data_request.rs
@@ -8,10 +8,6 @@ impl MainchainContract {
     #[payable]
     pub fn post_data_request(&mut self, data_request: String) {
         manage_storage_deposit!(self, "require", self.data_request_accumulator.push(&data_request));
-        println!(
-            "//////self.data_request_accumulator {:?}",
-            self.data_request_accumulator
-        );
     }
 
     pub fn compute_merkle_root(&self) -> Vec<u8> {

--- a/contracts/src/data_request.rs
+++ b/contracts/src/data_request.rs
@@ -8,6 +8,10 @@ impl MainchainContract {
     #[payable]
     pub fn post_data_request(&mut self, data_request: String) {
         manage_storage_deposit!(self, "require", self.data_request_accumulator.push(&data_request));
+        println!(
+            "//////self.data_request_accumulator {:?}",
+            self.data_request_accumulator
+        );
     }
 
     pub fn compute_merkle_root(&self) -> Vec<u8> {

--- a/contracts/src/fungible_token_test.rs
+++ b/contracts/src/fungible_token_test.rs
@@ -42,7 +42,7 @@ fn total_supply_includes_staked() {
     let mut contract = new_contract();
     let dao = make_test_account("dao_near".to_string());
     let bob = make_test_account("bob_near".to_string());
-    let bob_signature = bn254_sign(bob.clone(), "bob_near".to_string().as_bytes());
+    let bob_signature = bn254_sign(&bob.bn254_private_key.clone(), "bob_near".to_string().as_bytes());
     let deposit_amount = U128(INIT_MINIMUM_STAKE);
 
     // DAO transfers tokens to bob

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -82,7 +82,7 @@ pub struct MainchainContract {
     random_seed:                  CryptoHash,
     bootstrapping_phase:          bool,
     last_processed_epoch:         EpochHeight,
-    last_generated_random_number: u64,
+    last_generated_random_number: near_bigint::U256,
 }
 
 /// Contract public methods
@@ -94,7 +94,7 @@ impl MainchainContract {
         initial_supply: U128,
         metadata: FungibleTokenMetadata,
         committee_size: u64,
-        random_seed: u64,
+        random_seed: near_bigint::U256,
     ) -> Self {
         assert!(!env::state_exists(), "Already initialized");
         assert!(

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -24,7 +24,7 @@ use crate::{
 fn register_and_get_node() {
     let mut contract = new_contract();
     let bob = make_test_account("bob_near".to_string());
-    let bob_signature = bn254_sign(bob.clone(), &bob.clone().account_id.as_bytes());
+    let bob_signature = bn254_sign(&bob.bn254_private_key, &bob.clone().account_id.as_bytes());
 
     // register node
     testing_env!(get_context_with_deposit(bob.clone()));
@@ -47,7 +47,7 @@ fn register_and_get_node() {
 fn register_not_enough_storage() {
     let mut contract = new_contract();
     let bob = make_test_account("bob_near".to_string());
-    let bob_signature = bn254_sign(bob.clone(), &bob.clone().account_id.as_bytes());
+    let bob_signature = bn254_sign(&bob.bn254_private_key.clone(), &bob.clone().account_id.as_bytes());
 
     // register node
     testing_env!(get_context(bob.clone()));
@@ -62,7 +62,7 @@ fn register_not_enough_storage() {
 fn set_node_multi_addr() {
     let mut contract = new_contract();
     let bob = make_test_account("bob_near".to_string());
-    let bob_signature = bn254_sign(bob.clone(), &bob.clone().account_id.as_bytes());
+    let bob_signature = bn254_sign(&bob.bn254_private_key.clone(), &bob.clone().account_id.as_bytes());
 
     // register node
     testing_env!(get_context_with_deposit(bob.clone()));
@@ -92,9 +92,9 @@ fn get_nodes() {
     let alice = make_test_account("alice_near".to_string());
     let carol = make_test_account("carol_near".to_string());
     let deposit_amount = U128(INIT_MINIMUM_STAKE);
-    let bob_signature = bn254_sign(bob.clone(), "bob_near".to_string().as_bytes());
-    let alice_signature = bn254_sign(alice.clone(), "alice_near".to_string().as_bytes());
-    let carol_signature = bn254_sign(carol.clone(), "carol_near".to_string().as_bytes());
+    let bob_signature = bn254_sign(&bob.bn254_private_key.clone(), "bob_near".to_string().as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), "alice_near".to_string().as_bytes());
+    let carol_signature = bn254_sign(&carol.bn254_private_key.clone(), "carol_near".to_string().as_bytes());
 
     // DAO transfers tokens to bob, alice, and carol
     testing_env!(get_context_with_deposit(dao.clone()));
@@ -185,8 +185,8 @@ fn duplicated_key() {
     let mut contract = new_contract();
     let bob = make_test_account("bob_near".to_string());
     let alice = make_test_account("alice_near".to_string());
-    let bob_signature = bn254_sign(bob.clone(), "bob_near".to_string().as_bytes());
-    let alice_signature = bn254_sign(bob.clone(), "alice_near".to_string().as_bytes());
+    let bob_signature = bn254_sign(&bob.bn254_private_key.clone(), "bob_near".to_string().as_bytes());
+    let alice_signature = bn254_sign(&bob.bn254_private_key.clone(), "alice_near".to_string().as_bytes());
 
     // bob registers node
     testing_env!(get_context_with_deposit(bob.clone()));
@@ -219,7 +219,7 @@ fn deposit_withdraw() {
     contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
 
     // alice registers node
-    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), &alice.clone().account_id.as_bytes());
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
@@ -278,7 +278,7 @@ fn withdraw_wrong_account() {
     contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
 
     // alice registers node
-    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), &alice.clone().account_id.as_bytes());
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
@@ -328,7 +328,7 @@ fn deposit_withdraw_one_node_two_depositors() {
     contract.ft_transfer("bob_near".to_string().try_into().unwrap(), deposit_amount, None);
 
     // alice registers node
-    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), &alice.clone().account_id.as_bytes());
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
@@ -372,8 +372,8 @@ fn deposit_withdraw_two_nodes_one_depositor() {
     contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
 
     // alice and bob register nodes
-    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
-    let bob_signature = bn254_sign(bob.clone(), &bob.clone().account_id.as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), &alice.clone().account_id.as_bytes());
+    let bob_signature = bn254_sign(&bob.bn254_private_key.clone(), &bob.clone().account_id.as_bytes());
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),

--- a/contracts/src/test_utils.rs
+++ b/contracts/src/test_utils.rs
@@ -16,6 +16,7 @@ const TEST_DEPOSIT_AMOUNT: Balance = 618_720_000_000_000_000_000_000; // enough 
 pub fn new_contract() -> MainchainContract {
     let mut rng = rand::thread_rng();
     let random_seed = rng.gen::<u64>();
+
     let committee_size = 2;
     MainchainContract::new(
         "dao_near".to_string().try_into().unwrap(),
@@ -30,7 +31,7 @@ pub fn new_contract() -> MainchainContract {
             decimals:       24,
         },
         committee_size,
-        random_seed,
+        random_seed.into(),
     )
 }
 
@@ -121,6 +122,16 @@ pub fn get_context_with_deposit_at_block(test_account: TestAccount, block_index:
         .build()
 }
 
-pub fn bn254_sign(test_account: TestAccount, message: &[u8]) -> Signature {
-    ECDSA::sign(message, &test_account.bn254_private_key).unwrap()
+pub fn generate_bn254_key() -> (PublicKey, PrivateKey) {
+    let random_hex_string = hex::encode(Alphanumeric.sample_string(&mut rand::thread_rng(), 32));
+    let private_key_bytes = hex::decode(random_hex_string).unwrap();
+
+    let private_key = PrivateKey::try_from(private_key_bytes.as_slice()).unwrap();
+    let public_key = PublicKey::from_private_key(&private_key);
+
+    (public_key, private_key)
+}
+
+pub fn bn254_sign(private_key: &PrivateKey, message: &[u8]) -> Signature {
+    ECDSA::sign(message, private_key).unwrap()
 }

--- a/contracts/src/verify_test.rs
+++ b/contracts/src/verify_test.rs
@@ -12,7 +12,8 @@ fn test_verify_signed_msg() {
     testing_env!(get_context(bob));
 
     // Public key
-    let private_key = PrivateKey::try_from("2009da7287c158b126123c113d1c85241b6e3294dd75c643588630a8bc0f934c").unwrap();
+    let private_key = hex::decode("2009da7287c158b126123c113d1c85241b6e3294dd75c643588630a8bc0f934c").unwrap();
+    let private_key = PrivateKey::try_from(private_key.as_slice()).unwrap();
     let public_key = PublicKey::from_private_key(&private_key).to_compressed().unwrap();
 
     // Signature
@@ -39,8 +40,8 @@ fn test_verify_aggregate_signatures() {
     let msg = hex::decode("73616d706c65").unwrap();
 
     // Signature 1
-    let private_key_1 =
-        PrivateKey::try_from("1ab1126ff2e37c6e6eddea943ccb3a48f83b380b856424ee552e113595525565").unwrap();
+    let private_key_1_bytes = hex::decode("1ab1126ff2e37c6e6eddea943ccb3a48f83b380b856424ee552e113595525565").unwrap();
+    let private_key_1 = PrivateKey::try_from(private_key_1_bytes.as_slice()).unwrap();
     let sign_1 = ECDSA::sign(&msg, &private_key_1).unwrap();
     let sign_1_bytes = sign_1.to_compressed().unwrap();
 
@@ -48,8 +49,8 @@ fn test_verify_aggregate_signatures() {
     let public_key_1_bytes = public_key_1.to_compressed().unwrap();
 
     // Signature 2
-    let private_key_2 =
-        PrivateKey::try_from("2009da7287c158b126123c113d1c85241b6e3294dd75c643588630a8bc0f934c").unwrap();
+    let secret_key_2_bytes = hex::decode("2009da7287c158b126123c113d1c85241b6e3294dd75c643588630a8bc0f934c").unwrap();
+    let private_key_2 = PrivateKey::try_from(secret_key_2_bytes.as_slice()).unwrap();
     let sign_2 = ECDSA::sign(&msg, &private_key_2).unwrap();
     let sign_2_bytes = sign_2.to_compressed().unwrap();
 


### PR DESCRIPTION
Refactors `post_signed_batch()`:
- Adds `leader_signature` input parameter: the last generated random number signed by the slot leader
- Asserts the function caller is the slot leader
- Sets the new global `last_generated_random_number` = Hash(Sign_{ed25519}(R_{s-1}) || s )