### PR TITLE
Feat/contract withdraw restrictions

### DIFF
--- a/contracts/src/dao.rs
+++ b/contracts/src/dao.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub minimum_stake:            u128,
     pub epoch_delay_for_election: u64,
     pub committee_size:           u64,
+    pub withdraw_delay:           u64,
 }
 
 impl Default for Config {
@@ -25,6 +26,7 @@ impl Default for Config {
             minimum_stake:            INIT_MINIMUM_STAKE,
             epoch_delay_for_election: INIT_EPOCH_DELAY_FOR_ELECTION,
             committee_size:           DEFAULT_COMMITTEE_SIZE,
+            withdraw_delay:           INIT_EPOCH_DELAY_FOR_ELECTION,
         }
     }
 }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -23,6 +23,7 @@ use near_sdk::{
     BorshStorageKey,
     PanicOnDefault,
 };
+use node_registry::WithdrawRequest;
 
 use crate::{
     batch::{Batch, BatchHeight, BatchId},
@@ -45,6 +46,8 @@ enum MainchainStorageKeys {
     NodesByEd25519PublicKey,
     Depositors,
     Depositor { account_hash: [u8; 32] },
+    WithdrawRequests,
+    WithdrawRequest { account_hash: [u8; 32] },
 }
 
 /// Contract global state
@@ -83,6 +86,7 @@ pub struct MainchainContract {
     bootstrapping_phase:          bool,
     last_processed_epoch:         EpochHeight,
     last_generated_random_number: near_bigint::U256,
+    withdraw_requests:            LookupMap<Vec<u8>, LookupMap<AccountId, WithdrawRequest>>,
 }
 
 /// Contract public methods
@@ -124,6 +128,7 @@ impl MainchainContract {
             nodes_by_bn254_public_key: LookupMap::new(MainchainStorageKeys::NodesByBn254PublicKey),
             nodes_by_ed25519_public_key: LookupMap::new(MainchainStorageKeys::NodesByEd25519PublicKey),
             depositors: LookupMap::new(MainchainStorageKeys::Depositors),
+            withdraw_requests: LookupMap::new(MainchainStorageKeys::WithdrawRequests),
             random_seed: CryptoHash::default(),
             bootstrapping_phase: true,
             last_processed_epoch: 0,

--- a/contracts/src/node_registry.rs
+++ b/contracts/src/node_registry.rs
@@ -246,6 +246,22 @@ impl MainchainContract {
         });
     }
 
+    pub fn unregister_node(&mut self, ed25519_public_key: Vec<u8>) {
+        // assert the signer_account_pk matches the ed25519_public_key
+        assert!(
+            env::signer_account_pk().into_bytes().to_vec() == ed25519_public_key,
+            "Invalid ed25519_public_key"
+        );
+
+        // assert the node balance is zero
+        let node = self.get_expect_node_by_ed25519_public_key(ed25519_public_key.clone());
+        assert!(node.balance == 0, "Node balance is not zero");
+
+        // remove the node
+        let account_id = self.nodes_by_ed25519_public_key.get(&ed25519_public_key).unwrap();
+        self.inactive_nodes.remove(&account_id);
+    }
+
     /// Updates one of the node's fields
     #[payable]
     pub fn update_node(&mut self, command: UpdateNode) {

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -247,8 +247,12 @@ fn deposit_withdraw() {
     let node_balance = contract.get_node_balance("alice_near".to_string().try_into().unwrap());
     assert_eq!(node_balance, deposit_amount);
 
+    // alice requests withdraw
+    testing_env!(get_context_with_deposit(alice.clone()));
+    contract.request_withdraw(deposit_amount, alice.clone().ed25519_public_key.as_bytes().to_vec());
+
     // alice withdraws
-    testing_env!(get_context(alice.clone()));
+    testing_env!(get_context_with_deposit_at_block(alice.clone(), 1000000));
     contract.withdraw(deposit_amount, alice.ed25519_public_key.as_bytes().to_vec());
 
     // check alice's balance has increased again and the node balance has decreased
@@ -346,10 +350,16 @@ fn deposit_withdraw_one_node_two_depositors() {
     let node_balance = contract.get_node_balance("alice_near".to_string().try_into().unwrap());
     assert_eq!(node_balance, U128(deposit_amount.0 * 2));
 
+    // alice and bob request withdraws
+    testing_env!(get_context_with_deposit(alice.clone()));
+    contract.request_withdraw(deposit_amount, alice.clone().ed25519_public_key.as_bytes().to_vec());
+    testing_env!(get_context_with_deposit(bob.clone()));
+    contract.request_withdraw(deposit_amount, alice.clone().ed25519_public_key.as_bytes().to_vec());
+
     // alice and bob withdraw
-    testing_env!(get_context(alice.clone()));
+    testing_env!(get_context_with_deposit_at_block(alice.clone(), 1000000));
     contract.withdraw(deposit_amount, alice.clone().ed25519_public_key.as_bytes().to_vec());
-    testing_env!(get_context(bob));
+    testing_env!(get_context_with_deposit_at_block(bob, 1000000));
     contract.withdraw(deposit_amount, alice.ed25519_public_key.as_bytes().to_vec());
 
     // check total deposited amount is now 0
@@ -414,8 +424,19 @@ fn deposit_withdraw_two_nodes_one_depositor() {
     let node_balance = contract.get_node_balance("bob_near".to_string().try_into().unwrap());
     assert_eq!(node_balance, U128(deposit_amount.0 / 2));
 
-    // alice withdraws from both pools
+    // alice requests withdraws from both pools
     testing_env!(get_context(alice.clone()));
+    contract.request_withdraw(
+        U128(deposit_amount.0 / 2),
+        alice.clone().ed25519_public_key.as_bytes().to_vec(),
+    );
+    contract.request_withdraw(
+        U128(deposit_amount.0 / 2),
+        bob.clone().ed25519_public_key.as_bytes().to_vec(),
+    );
+
+    // alice withdraws from both pools
+    testing_env!(get_context_with_deposit_at_block(alice.clone(), 1000000));
     contract.withdraw(U128(deposit_amount.0 / 2), alice.ed25519_public_key.as_bytes().to_vec());
     contract.withdraw(U128(deposit_amount.0 / 2), bob.ed25519_public_key.as_bytes().to_vec());
 

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -491,7 +491,7 @@ fn cancel_withdraw_request() {
     contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
 
     // alice registers node
-    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), &alice.clone().account_id.as_bytes());
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
@@ -534,7 +534,7 @@ fn withdraw_before_epoch() {
     contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
 
     // alice registers node
-    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), &alice.clone().account_id.as_bytes());
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
@@ -573,7 +573,7 @@ fn unregister_nonzero_node() {
     contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
 
     // alice registers node
-    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
+    let alice_signature = bn254_sign(&alice.bn254_private_key.clone(), &alice.clone().account_id.as_bytes());
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -429,7 +429,7 @@ fn deposit_withdraw_two_nodes_one_depositor() {
     assert_eq!(node_balance, U128(deposit_amount.0 / 2));
 
     // alice requests withdraws from both pools
-    testing_env!(get_context(alice.clone()));
+    testing_env!(get_context_with_deposit(alice.clone()));
     contract.request_withdraw(
         U128(deposit_amount.0 / 2),
         alice.clone().ed25519_public_key.as_bytes().to_vec(),

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -520,7 +520,7 @@ fn cancel_withdraw_request() {
 }
 
 #[test]
-#[should_panic(expected = "Not enough epochs have passed to withdraw")]
+#[should_panic(expected = "2 epochs remain until withdrawal is allowed")]
 fn withdraw_before_epoch() {
     let mut contract = new_contract();
     let dao = make_test_account("dao_near".to_string());

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -264,6 +264,10 @@ fn deposit_withdraw() {
         contract.get_node_balance("alice_near".to_string().try_into().unwrap()),
         U128(0)
     );
+
+    // unregister node now that balance is zero
+    testing_env!(get_context_with_deposit(alice.clone()));
+    contract.unregister_node(alice.clone().ed25519_public_key.as_bytes().to_vec());
 }
 
 #[test]
@@ -552,4 +556,35 @@ fn withdraw_before_epoch() {
 
     // alice withdraws without waiting
     contract.withdraw(deposit_amount, alice.ed25519_public_key.as_bytes().to_vec());
+}
+
+#[test]
+#[should_panic(expected = "Node balance is not zero")]
+fn unregister_nonzero_node() {
+    let mut contract = new_contract();
+    let dao = make_test_account("dao_near".to_string());
+    let alice = make_test_account("alice_near".to_string());
+    let deposit_amount = U128(INIT_MINIMUM_STAKE);
+
+    // DAO transfers tokens to alice
+    testing_env!(get_context_with_deposit(dao.clone()));
+    contract.storage_deposit(Some("alice_near".to_string().try_into().unwrap()), None);
+    testing_env!(get_context_for_ft_transfer(dao));
+    contract.ft_transfer("alice_near".to_string().try_into().unwrap(), deposit_amount, None);
+
+    // alice registers node
+    let alice_signature = bn254_sign(alice.clone(), &alice.clone().account_id.as_bytes());
+    testing_env!(get_context_with_deposit(alice.clone()));
+    contract.register_node(
+        "0.0.0.0:8080".to_string(),
+        alice.clone().bn254_public_key.to_compressed().unwrap(),
+        alice_signature.to_compressed().unwrap(),
+    );
+
+    // alice deposits into pool
+    testing_env!(get_context_with_deposit(alice.clone()));
+    contract.deposit(deposit_amount, alice.clone().ed25519_public_key.as_bytes().to_vec());
+
+    // alice tries to unregister node
+    contract.unregister_node(alice.clone().ed25519_public_key.as_bytes().to_vec());
 }

--- a/contracts/src/test_utils.rs
+++ b/contracts/src/test_utils.rs
@@ -1,10 +1,7 @@
 use bn254::{PrivateKey, PublicKey, Signature, ECDSA};
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
 use near_sdk::{json_types::U128, test_utils::VMContextBuilder, AccountId, Balance, VMContext};
-use rand::{
-    distributions::{Alphanumeric, DistString},
-    Rng,
-};
+use rand::Rng;
 
 use crate::{
     consts::{DATA_IMAGE_SVG_ICON, INITIAL_SUPPLY},

--- a/contracts/src/test_utils.rs
+++ b/contracts/src/test_utils.rs
@@ -1,7 +1,10 @@
 use bn254::{PrivateKey, PublicKey, Signature, ECDSA};
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
 use near_sdk::{json_types::U128, test_utils::VMContextBuilder, AccountId, Balance, VMContext};
-use rand::Rng;
+use rand::{
+    distributions::{Alphanumeric, DistString},
+    Rng,
+};
 
 use crate::{
     consts::{DATA_IMAGE_SVG_ICON, INITIAL_SUPPLY},


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Similar to how nodes should only be activated after a waiting period, nodes should only be able to withdraw after a waiting period.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Added `request_withdraw()` function that allows user to withdraw given amount after x epochs. Only one withdraw request is allowed at one time
- Added `cancel_withdraw_request()` to remove previously created withdraw request
- Added `unregister_node()` function that allows user to return storage deposit and delete the node when balance is 0

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

- cancel_withdraw_request() - tests `cancel_withdraw_request()` deletes a pending request
- withdraw_before_epoch() - tests that user cannot immediately withdraw funds after creating withdraw request
- unregister_nonzero_node() - tests that user cannot unregister node if there is balance remaining
