### PR TITLE
feat(contracts): return slot and slot leader with merkle root

### DIFF
--- a/common/src/node/get.rs
+++ b/common/src/node/get.rs
@@ -47,3 +47,10 @@ impl ToString for GetNodesArgs {
         json.to_string()
     }
 }
+
+#[derive(Deserialize, Serialize)]
+pub struct ComputeMerkleRootResult {
+    pub merkle_root:         Vec<u8>,
+    pub current_slot:        u64,
+    pub current_slot_leader: Option<String>,
+}

--- a/contracts/src/batch.rs
+++ b/contracts/src/batch.rs
@@ -48,7 +48,7 @@ impl MainchainContract {
         signers: Vec<AccountId>,
         leader_signature: Vec<u8>,
     ) {
-        assert_eq!(self.get_current_slot_leader(), env::signer_account_id());
+        assert_eq!(self.get_current_slot_leader().unwrap(), env::signer_account_id());
         let leader_pk = PublicKey::from_compressed(
             self.active_nodes
                 .get(&env::signer_account_id())
@@ -98,9 +98,9 @@ impl MainchainContract {
         );
 
         // verify aggregate signature
-        let merkle_root = self.compute_merkle_root();
+        let merkle_root = self.internal_compute_merkle_root();
         assert!(
-            self.bn254_verify(merkle_root, aggregate_signature, aggregate_public_key),
+            self.bn254_verify(merkle_root.clone(), aggregate_signature, aggregate_public_key),
             "Invalid aggregate signature"
         );
 
@@ -119,7 +119,7 @@ impl MainchainContract {
         let batch_id = CryptoHash::hash_borsh(&MerklizedBatch {
             prev_root: self.get_latest_batch_id(),
             header,
-            transactions: self.compute_merkle_root(),
+            transactions: merkle_root,
         });
 
         manage_storage_deposit!(self, {

--- a/contracts/src/batch_test.rs
+++ b/contracts/src/batch_test.rs
@@ -72,7 +72,7 @@ fn post_signed_batch() {
         .for_each(|comittee| assert_eq!(comittee.len() as u64, contract.config.committee_size));
 
     // get the merkle root (for all nodes to sign)
-    let merkle_root = contract.compute_merkle_root();
+    let merkle_root = contract.compute_merkle_root().merkle_root;
 
     // gather the chosen committee test accounts for signing
     let chosen_committee_account_ids = contract.get_committees().first().unwrap().clone();
@@ -86,7 +86,7 @@ fn post_signed_batch() {
 
     // find the slot leader
     testing_env!(get_context_for_post_signed_batch(test_acc.clone()));
-    let slot_leader_account_id = contract.get_current_slot_leader();
+    let slot_leader_account_id = contract.get_current_slot_leader().unwrap();
     let slot_leader_test_account = test_accounts.get(&slot_leader_account_id).unwrap();
 
     // sign and post the batch
@@ -151,7 +151,7 @@ fn post_signed_batch_with_wrong_leader_sig() {
     contract.process_epoch();
 
     // get the merkle root (for all nodes to sign)
-    let merkle_root = contract.compute_merkle_root();
+    let merkle_root = contract.compute_merkle_root().merkle_root;
 
     // gather the chosen committee test accounts for signing
     let chosen_committee_account_ids = contract.get_committees().first().unwrap().clone();
@@ -163,7 +163,7 @@ fn post_signed_batch_with_wrong_leader_sig() {
 
     // find the slot leader
     testing_env!(get_context_for_post_signed_batch(test_acc.clone()));
-    let slot_leader_account_id = contract.get_current_slot_leader();
+    let slot_leader_account_id = contract.get_current_slot_leader().unwrap();
     let slot_leader_test_account = test_accounts.get(&slot_leader_account_id).unwrap();
 
     // sign and post the batch with an invalid signature

--- a/contracts/src/committee.rs
+++ b/contracts/src/committee.rs
@@ -52,8 +52,8 @@ impl MainchainContract {
         self.last_generated_random_number
     }
 
-    pub fn get_current_slot_leader(&self) -> AccountId {
-        let current_committee = self.committees.first().expect("Couldn't fetch current committee");
+    pub fn get_current_slot_leader(&self) -> Option<AccountId> {
+        let current_committee = self.committees.first()?;
         let hash = Sha256::digest(
             [
                 self.last_generated_random_number.to_le_bytes().as_ref(),
@@ -63,10 +63,7 @@ impl MainchainContract {
         );
         let prn: near_bigint::U256 = near_bigint::U256::from_little_endian(&hash);
         let chosen_index = (prn % self.config.committee_size).as_usize();
-        current_committee
-            .get(chosen_index)
-            .expect("Couldn't fetch chosen validator")
-            .clone()
+        current_committee.get(chosen_index).cloned()
     }
 }
 

--- a/contracts/src/data_request.rs
+++ b/contracts/src/data_request.rs
@@ -1,6 +1,14 @@
 use near_sdk::{env, near_bindgen};
+use seda_common::ComputeMerkleRootResult;
 
 use crate::{manage_storage_deposit, merkle::merklize, MainchainContract, MainchainContractExt};
+
+/// Contract private methods
+impl MainchainContract {
+    pub fn internal_compute_merkle_root(&self) -> Vec<u8> {
+        merklize(&self.data_request_accumulator.to_vec()).0.try_into().unwrap()
+    }
+}
 
 /// Contract public methods
 #[near_bindgen]
@@ -10,7 +18,13 @@ impl MainchainContract {
         manage_storage_deposit!(self, "require", self.data_request_accumulator.push(&data_request));
     }
 
-    pub fn compute_merkle_root(&self) -> Vec<u8> {
-        merklize(&self.data_request_accumulator.to_vec()).0.try_into().unwrap()
+    /// Returns the merkle root of the data request accumulator, the current
+    /// slot and the current slot leader
+    pub fn compute_merkle_root(&self) -> ComputeMerkleRootResult {
+        ComputeMerkleRootResult {
+            merkle_root:         self.internal_compute_merkle_root(),
+            current_slot:        self.get_current_slot(),
+            current_slot_leader: self.get_current_slot_leader().map(|x| x.to_string()),
+        }
     }
 }

--- a/contracts/src/integration_test.rs
+++ b/contracts/src/integration_test.rs
@@ -71,7 +71,7 @@ fn integration_test_1() {
             }
 
             // get the merkle root (for all nodes to sign)
-            let merkle_root = contract.compute_merkle_root();
+            let merkle_root = contract.compute_merkle_root().merkle_root;
 
             // gather the chosen committee test accounts for signing
             let chosen_committee_account_ids = contract.get_committees().first().unwrap().clone();
@@ -83,7 +83,7 @@ fn integration_test_1() {
 
             // find the slot leader
             testing_env!(get_context_at_block(block_number));
-            let slot_leader_account_id = contract.get_current_slot_leader();
+            let slot_leader_account_id = contract.get_current_slot_leader().unwrap();
             let slot_leader_test_account = test_accounts.get(&slot_leader_account_id).unwrap();
 
             // sign and post the batch


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To guarantee the merkle root belongs to a particular slot

## Explanation of Changes

- Created `ComputeMerkleRootResult` struct in common
- Refactored `get_current_slot_leader()` to return `Option<AccountId>`
- Created `internal_compute_merkle_root()` and updated `compute_merkle_root()` to call this and other related functions for slot and slot leader

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

n/a

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
-->

n/a
