### PR TITLE
fix(contracts): implement BorshDeserialize/BorshSerialize for Compute…

### DIFF
--- a/common/src/node/get.rs
+++ b/common/src/node/get.rs
@@ -48,7 +48,7 @@ impl ToString for GetNodesArgs {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, BorshDeserialize, BorshSerialize, Debug, Clone)]
 pub struct ComputeMerkleRootResult {
     pub merkle_root:         Vec<u8>,
     pub current_slot:        u64,


### PR DESCRIPTION
Not implementing BorshDeserialize/BorshSerialize for ComputeMerkleRootResult throws an error when queried on testnet: "`invalid type: integer `27`, expected a sequence`"