### PR TITLE
feat(contracts): allow empty batches to be posted

### DIFF
--- a/contracts/src/batch.rs
+++ b/contracts/src/batch.rs
@@ -82,12 +82,6 @@ impl MainchainContract {
             let new_random: near_bigint::U256 = near_bigint::U256::from_little_endian(&hash);
             self.last_generated_random_number = new_random;
 
-            // require the data request accumulator to be non-empty
-            assert!(
-                !self.data_request_accumulator.is_empty(),
-                "Data request accumulator is empty"
-            );
-
             // reconstruct the aggregate public key from signers[] to verify all signers are
             // eligible for this batch while also verifying individual eligibility
             let current_committee = self.committees.get(&self.get_current_epoch()).unwrap();


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Batches with zero data requests should still be able to be signed and posted to the mainchain contract according to our spec. This is to remove the incentive from validators to create "fake" data requests from which to receive batch rewards.

## Explanation of Changes

Removed assertion in `post_signed_batch()` for `data_request_accumulator` to be non-empty.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Created a new test `post_empty_signed_batch()` that fails with the assertion but passes now that it is removed.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
-->

N/A