### PR TITLE
feat: use uncompressed pks and sigs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "bn254"
 version = "0.0.1"
-source = "git+https://github.com/sedaprotocol/bn254?branch=main#658c3a26f519b004d071b6f9020cc37605196ab4"
+source = "git+https://github.com/mennatabuelnaga/bn254?branch=main#c6b7964695f71cff86c691646f1a8e6f1211cdda"
 dependencies = [
  "borsh",
  "byteorder",
@@ -3468,7 +3468,7 @@ dependencies = [
  "near-vm-errors 0.14.0",
  "ripemd",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "sha3",
  "zeropool-bn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "bn254"
 version = "0.0.1"
-source = "git+https://github.com/mennatabuelnaga/bn254?branch=main#c6b7964695f71cff86c691646f1a8e6f1211cdda"
+source = "git+https://github.com/sedaprotocol/bn254?branch=main#f61ef051e1f4c8c924fe4b1fc51c4f32bc40e4e2"
 dependencies = [
  "borsh",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,7 @@ actix = "0.13"
 async-trait = "0.1"
 bs58 = "0.4.0"
 base64 = "0.13"
-
-# bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
-bn254 = { git = "https://github.com/mennatabuelnaga/bn254", branch = "main" }
-
+bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
 borsh = { version = "0.9", default-features = false }
 clap = { version = "4.1", default-features = false }
 clap-markdown = { version = "0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,10 @@ actix = "0.13"
 async-trait = "0.1"
 bs58 = "0.4.0"
 base64 = "0.13"
-bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
+
+# bn254 = { git = "https://github.com/sedaprotocol/bn254", branch = "main" }
+bn254 = { git = "https://github.com/mennatabuelnaga/bn254", branch = "main" }
+
 borsh = { version = "0.9", default-features = false }
 clap = { version = "4.1", default-features = false }
 clap-markdown = { version = "0.1", default-features = false }

--- a/cli/src/cli/commands/node/register.rs
+++ b/cli/src/cli/commands/node/register.rs
@@ -21,13 +21,13 @@ impl Register {
         let node_config = &config.node.to_config(self.node_config)?;
 
         let sig = bn254::ECDSA::sign(
-            node_config.keypair_bn254.public_key.to_compressed()?,
+            node_config.keypair_bn254.public_key.to_uncompressed()?,
             &node_config.keypair_bn254.private_key,
         )?;
         let args = RegisterNodeArgs {
             multi_addr:       self.socket_address,
-            bn254_public_key: node_config.keypair_bn254.public_key.to_compressed()?,
-            signature:        sig.to_compressed()?,
+            bn254_public_key: node_config.keypair_bn254.public_key.to_uncompressed()?,
+            signature:        sig.to_uncompressed()?,
         }
         .to_string();
         call::<Option<serde_json::Value>>(

--- a/common/src/node/mod.rs
+++ b/common/src/node/mod.rs
@@ -41,7 +41,12 @@ impl NodeInfo {
                 rng.gen_range(1..65535)
             ),
             balance:            rng.gen_range(0..u128::MAX),
-            bn254_public_key:   master_key.derive_bn254(0).unwrap().public_key.to_compressed().unwrap(),
+            bn254_public_key:   master_key
+                .derive_bn254(0)
+                .unwrap()
+                .public_key
+                .to_uncompressed()
+                .unwrap(),
             ed25519_public_key: master_key.derive_ed25519(0).unwrap().public_key.as_bytes().to_vec(),
         }
     }

--- a/contracts/src/batch.rs
+++ b/contracts/src/batch.rs
@@ -60,15 +60,11 @@ impl MainchainContract {
             log!("slot leader: {}", self.get_current_slot_leader().unwrap());
             log!("block: {}", env::block_height());
             assert_eq!(self.get_current_slot_leader().unwrap(), env::signer_account_id());
-            let leader_pk = PublicKey::from_compressed(
-                self.active_nodes
-                    .get(&env::signer_account_id())
-                    .unwrap()
-                    .bn254_public_key,
-            )
-            .unwrap()
-            .to_compressed()
-            .unwrap();
+            let leader_pk = self
+                .active_nodes
+                .get(&env::signer_account_id())
+                .unwrap()
+                .bn254_public_key;
             assert!(
                 self.bn254_verify(
                     self.last_generated_random_number.to_le_bytes().to_vec(),
@@ -90,16 +86,16 @@ impl MainchainContract {
                 "Node is not part of the committee"
             );
             let aggregate_public_key_reconstructed = signers.iter().skip(1).fold(
-                PublicKey::from_compressed(self.active_nodes.get(&signers[0]).unwrap().bn254_public_key).unwrap(),
+                PublicKey::from_uncompressed(self.active_nodes.get(&signers[0]).unwrap().bn254_public_key).unwrap(),
                 |acc, signer| {
                     assert!(current_committee.contains(signer), "Node is not part of the committee");
                     let signer_public_key =
-                        PublicKey::from_compressed(self.active_nodes.get(signer).unwrap().bn254_public_key).unwrap();
+                        PublicKey::from_uncompressed(self.active_nodes.get(signer).unwrap().bn254_public_key).unwrap();
                     acc + signer_public_key
                 },
             );
             assert!(
-                aggregate_public_key_reconstructed.to_compressed().unwrap() == aggregate_public_key,
+                aggregate_public_key_reconstructed.to_uncompressed().unwrap() == aggregate_public_key,
                 "Invalid aggregate public key"
             );
 

--- a/contracts/src/batch_test.rs
+++ b/contracts/src/batch_test.rs
@@ -219,8 +219,8 @@ fn post_empty_signed_batch() {
         // register nodes
         contract.register_node(
             "0.0.0.0:8080".to_string(),
-            acc.bn254_public_key.to_compressed().unwrap(),
-            sig.to_compressed().unwrap(),
+            acc.bn254_public_key.to_uncompressed().unwrap(),
+            sig.to_uncompressed().unwrap(),
         );
         // deposit into contract
         testing_env!(get_context_with_deposit(acc.clone()));
@@ -275,10 +275,10 @@ fn post_empty_signed_batch() {
         &contract.last_generated_random_number.to_le_bytes(),
     );
     contract.post_signed_batch(
-        agg_signature.to_compressed().unwrap(),
-        agg_public_key.to_compressed().unwrap(),
+        agg_signature.to_uncompressed().unwrap(),
+        agg_public_key.to_uncompressed().unwrap(),
         chosen_committee_account_ids,
-        leader_sig.to_compressed().unwrap(),
+        leader_sig.to_uncompressed().unwrap(),
     );
     assert_eq!(contract.num_batches, num_batches + 1);
 }

--- a/contracts/src/batch_test.rs
+++ b/contracts/src/batch_test.rs
@@ -50,8 +50,8 @@ fn post_signed_batch() {
         // register nodes
         contract.register_node(
             "0.0.0.0:8080".to_string(),
-            acc.bn254_public_key.to_compressed().unwrap(),
-            sig.to_compressed().unwrap(),
+            acc.bn254_public_key.to_uncompressed().unwrap(),
+            sig.to_uncompressed().unwrap(),
         );
         // deposit into contract
         testing_env!(get_context_with_deposit(acc.clone()));
@@ -106,10 +106,10 @@ fn post_signed_batch() {
         &contract.last_generated_random_number.to_le_bytes(),
     );
     contract.post_signed_batch(
-        agg_signature.to_compressed().unwrap(),
-        agg_public_key.to_compressed().unwrap(),
+        agg_signature.to_uncompressed().unwrap(),
+        agg_public_key.to_uncompressed().unwrap(),
         chosen_committee_account_ids,
-        leader_sig.to_compressed().unwrap(),
+        leader_sig.to_uncompressed().unwrap(),
     );
     assert_eq!(contract.num_batches, num_batches + 1);
 }
@@ -147,8 +147,8 @@ fn post_signed_batch_with_wrong_leader_sig() {
         // register nodes
         contract.register_node(
             "0.0.0.0:8080".to_string(),
-            acc.bn254_public_key.to_compressed().unwrap(),
-            sig.to_compressed().unwrap(),
+            acc.bn254_public_key.to_uncompressed().unwrap(),
+            sig.to_uncompressed().unwrap(),
         );
         // deposit into contract
         testing_env!(get_context_with_deposit(acc.clone()));
@@ -182,10 +182,10 @@ fn post_signed_batch_with_wrong_leader_sig() {
     let random_seed = rng.gen::<u64>();
     let invalid_leader_sig = bn254_sign(&slot_leader_test_account.bn254_private_key, &random_seed.to_le_bytes());
     contract.post_signed_batch(
-        agg_signature.to_compressed().unwrap(),
-        agg_public_key.to_compressed().unwrap(),
+        agg_signature.to_uncompressed().unwrap(),
+        agg_public_key.to_uncompressed().unwrap(),
         chosen_committee_account_ids,
-        invalid_leader_sig.to_compressed().unwrap(),
+        invalid_leader_sig.to_uncompressed().unwrap(),
     );
     assert_eq!(contract.num_batches, num_batches + 1);
 }

--- a/contracts/src/committee_selection_test.rs
+++ b/contracts/src/committee_selection_test.rs
@@ -34,8 +34,8 @@ fn test_committee_selection() {
         testing_env!(get_context_with_deposit(acc.clone()));
         contract.register_node(
             "0.0.0.0:8080".to_string(),
-            acc.bn254_public_key.to_compressed().unwrap(),
-            sig.to_compressed().unwrap(),
+            acc.bn254_public_key.to_uncompressed().unwrap(),
+            sig.to_uncompressed().unwrap(),
         );
         testing_env!(get_context_with_deposit(acc.clone()));
         contract.deposit(deposit_amount, acc.ed25519_public_key.into_bytes());

--- a/contracts/src/fungible_token_test.rs
+++ b/contracts/src/fungible_token_test.rs
@@ -55,8 +55,8 @@ fn total_supply_includes_staked() {
     testing_env!(get_context_with_deposit(bob.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        bob_signature.to_uncompressed().unwrap(),
     );
 
     // bob deposits

--- a/contracts/src/integration_test.rs
+++ b/contracts/src/integration_test.rs
@@ -98,10 +98,10 @@ fn integration_test_1() {
                 &contract.last_generated_random_number.to_le_bytes(),
             );
             contract.post_signed_batch(
-                agg_signature.to_compressed().unwrap(),
-                agg_public_key.to_compressed().unwrap(),
+                agg_signature.to_uncompressed().unwrap(),
+                agg_public_key.to_uncompressed().unwrap(),
                 chosen_committee_account_ids,
-                leader_sig.to_compressed().unwrap(),
+                leader_sig.to_uncompressed().unwrap(),
             );
             assert_eq!(contract.num_batches, num_batches + 1);
 

--- a/contracts/src/node_registry_test.rs
+++ b/contracts/src/node_registry_test.rs
@@ -27,8 +27,8 @@ fn register_and_get_node() {
     testing_env!(get_context_with_deposit(bob.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        bob_signature.to_uncompressed().unwrap(),
     );
     assert_eq!(get_logs(), vec!["bob_near registered node"]);
     // check owner and multi_addr
@@ -40,7 +40,7 @@ fn register_and_get_node() {
 }
 
 #[test]
-#[should_panic(expected = "Insufficient storage, need 5240000000000000000000")]
+#[should_panic(expected = "Insufficient storage, need 6500000000000000000000")]
 fn register_not_enough_storage() {
     let mut contract = new_contract();
     let bob = make_test_account("bob_near".to_string());
@@ -50,8 +50,8 @@ fn register_not_enough_storage() {
     testing_env!(get_context(bob.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        bob_signature.to_uncompressed().unwrap(),
     );
 }
 
@@ -65,8 +65,8 @@ fn set_node_multi_addr() {
     testing_env!(get_context_with_deposit(bob.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        bob_signature.to_uncompressed().unwrap(),
     );
     assert_eq!(get_logs(), vec!["bob_near registered node"]);
 
@@ -109,20 +109,20 @@ fn get_nodes() {
     testing_env!(get_context_with_deposit(bob.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        bob_signature.to_uncompressed().unwrap(),
     );
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "1.1.1.1:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
     testing_env!(get_context_with_deposit(carol.clone()));
     contract.register_node(
         "2.2.2.2:8080".to_string(),
-        carol.bn254_public_key.to_compressed().unwrap(),
-        carol_signature.to_compressed().unwrap(),
+        carol.bn254_public_key.to_uncompressed().unwrap(),
+        carol_signature.to_uncompressed().unwrap(),
     );
 
     // all nodes deposit the minimum stake
@@ -142,21 +142,21 @@ fn get_nodes() {
         account_id:         "bob_near".to_string(),
         balance:            deposit_amount.0,
         multi_addr:         "0.0.0.0:8080".to_string(),
-        bn254_public_key:   bob.clone().bn254_public_key.to_compressed().unwrap(),
+        bn254_public_key:   bob.clone().bn254_public_key.to_uncompressed().unwrap(),
         ed25519_public_key: bob.ed25519_public_key.into_bytes(),
     };
     let node2 = NodeInfo {
         account_id:         "alice_near".to_string(),
         balance:            deposit_amount.0,
         multi_addr:         "1.1.1.1:8080".to_string(),
-        bn254_public_key:   alice.clone().bn254_public_key.to_compressed().unwrap(),
+        bn254_public_key:   alice.clone().bn254_public_key.to_uncompressed().unwrap(),
         ed25519_public_key: alice.ed25519_public_key.into_bytes(),
     };
     let node3 = NodeInfo {
         account_id:         "carol_near".to_string(),
         balance:            deposit_amount.0,
         multi_addr:         "2.2.2.2:8080".to_string(),
-        bn254_public_key:   carol.clone().bn254_public_key.to_compressed().unwrap(),
+        bn254_public_key:   carol.clone().bn254_public_key.to_uncompressed().unwrap(),
         ed25519_public_key: carol.ed25519_public_key.into_bytes(),
     };
 
@@ -195,16 +195,16 @@ fn duplicated_key() {
     testing_env!(get_context_with_deposit(bob.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        bob_signature.to_uncompressed().unwrap(),
     );
 
     // alice registers node with duplicated key
     testing_env!(get_context_with_deposit(alice));
     contract.register_node(
         "1.1.1.1:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
 }
 
@@ -226,8 +226,8 @@ fn deposit_withdraw() {
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
 
     // alice deposits into pool
@@ -290,8 +290,8 @@ fn withdraw_wrong_account() {
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
 
     // alice deposits into pool
@@ -337,8 +337,8 @@ fn deposit_withdraw_one_node_two_depositors() {
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
 
     // alice and bob deposit into alice's pool
@@ -388,14 +388,14 @@ fn deposit_withdraw_two_nodes_one_depositor() {
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
     testing_env!(get_context_with_deposit(bob.clone()));
     contract.register_node(
         "1.1.1.1:8080".to_string(),
-        bob.bn254_public_key.to_compressed().unwrap(),
-        bob_signature.to_compressed().unwrap(),
+        bob.bn254_public_key.to_uncompressed().unwrap(),
+        bob_signature.to_uncompressed().unwrap(),
     );
 
     // alice deposits into alice and bob's pool
@@ -480,8 +480,8 @@ fn cancel_withdraw_request() {
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
 
     // alice deposits into pool
@@ -523,8 +523,8 @@ fn withdraw_before_epoch() {
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
 
     // alice deposits into pool
@@ -562,8 +562,8 @@ fn unregister_nonzero_node() {
     testing_env!(get_context_with_deposit(alice.clone()));
     contract.register_node(
         "0.0.0.0:8080".to_string(),
-        alice.bn254_public_key.to_compressed().unwrap(),
-        alice_signature.to_compressed().unwrap(),
+        alice.bn254_public_key.to_uncompressed().unwrap(),
+        alice_signature.to_uncompressed().unwrap(),
     );
 
     // alice deposits into pool

--- a/contracts/src/test_utils.rs
+++ b/contracts/src/test_utils.rs
@@ -196,8 +196,8 @@ pub fn make_register_test_accounts(
         testing_env!(get_context_with_deposit(acc.clone()));
         contract.register_node(
             "0.0.0.0:8080".to_string(),
-            acc.bn254_public_key.to_compressed().unwrap(),
-            sig.to_compressed().unwrap(),
+            acc.bn254_public_key.to_uncompressed().unwrap(),
+            sig.to_uncompressed().unwrap(),
         );
         // deposit into contract
         testing_env!(get_context_with_deposit(acc.clone()));

--- a/contracts/src/verify.rs
+++ b/contracts/src/verify.rs
@@ -1,4 +1,4 @@
-use bn254::format_pairing_check_values;
+use bn254::format_pairing_check_uncompressed_values;
 use near_sdk::near_bindgen;
 use near_sys::alt_bn128_pairing_check;
 
@@ -7,7 +7,7 @@ use crate::{MainchainContract, MainchainContractExt};
 #[near_bindgen]
 impl MainchainContract {
     pub fn bn254_verify(&mut self, message: Vec<u8>, signature: Vec<u8>, public_key: Vec<u8>) -> bool {
-        let vals = format_pairing_check_values(message, signature, public_key).unwrap();
+        let vals = format_pairing_check_uncompressed_values(message, signature, public_key).unwrap();
 
         let res;
         unsafe {

--- a/contracts/src/verify_test.rs
+++ b/contracts/src/verify_test.rs
@@ -1,4 +1,4 @@
-use bn254::{PrivateKey, PublicKey, ECDSA};
+use bn254::{PrivateKey, PublicKey, Signature, ECDSA};
 use near_sdk::testing_env;
 
 use super::test_utils::{get_context, new_contract};
@@ -14,19 +14,20 @@ fn test_verify_signed_msg() {
     // Public key
     let private_key = hex::decode("2009da7287c158b126123c113d1c85241b6e3294dd75c643588630a8bc0f934c").unwrap();
     let private_key = PrivateKey::try_from(private_key.as_slice()).unwrap();
-    let public_key = PublicKey::from_private_key(&private_key).to_compressed().unwrap();
+    let public_key = PublicKey::from_private_key(&private_key).to_uncompressed().unwrap();
 
     // Signature
     let signature_vec = hex::decode("020f047a153e94b5f109e4013d1bd078112817cf0d58cdf6ba8891f9849852ba5b").unwrap();
+    let sig = Signature::from_compressed(signature_vec)
+        .unwrap()
+        .to_uncompressed()
+        .unwrap();
 
     // Message signed
     let msg = hex::decode("73616d706c65").unwrap();
 
     // Verify signature
-    assert!(
-        contract.bn254_verify(msg, signature_vec, public_key),
-        "Verification failed"
-    );
+    assert!(contract.bn254_verify(msg, sig, public_key), "Verification failed");
 }
 
 /// Test aggregate signature verification
@@ -43,23 +44,23 @@ fn test_verify_aggregate_signatures() {
     let private_key_1_bytes = hex::decode("1ab1126ff2e37c6e6eddea943ccb3a48f83b380b856424ee552e113595525565").unwrap();
     let private_key_1 = PrivateKey::try_from(private_key_1_bytes.as_slice()).unwrap();
     let sign_1 = ECDSA::sign(&msg, &private_key_1).unwrap();
-    let sign_1_bytes = sign_1.to_compressed().unwrap();
+    let sign_1_bytes = sign_1.to_uncompressed().unwrap();
 
     let public_key_1 = PublicKey::from_private_key(&private_key_1);
-    let public_key_1_bytes = public_key_1.to_compressed().unwrap();
+    let public_key_1_bytes = public_key_1.to_uncompressed().unwrap();
 
     // Signature 2
     let secret_key_2_bytes = hex::decode("2009da7287c158b126123c113d1c85241b6e3294dd75c643588630a8bc0f934c").unwrap();
     let private_key_2 = PrivateKey::try_from(secret_key_2_bytes.as_slice()).unwrap();
     let sign_2 = ECDSA::sign(&msg, &private_key_2).unwrap();
-    let sign_2_bytes = sign_2.to_compressed().unwrap();
+    let sign_2_bytes = sign_2.to_uncompressed().unwrap();
 
     let public_key_2 = PublicKey::from_private_key(&private_key_2);
-    let public_key_2_bytes = public_key_2.to_compressed().unwrap();
+    let public_key_2_bytes = public_key_2.to_uncompressed().unwrap();
 
     // Public Key and Signature aggregation
-    let agg_public_key = (public_key_1 + public_key_2).to_compressed().unwrap();
-    let agg_signature = (sign_1 + sign_2).to_compressed().unwrap();
+    let agg_public_key = (public_key_1 + public_key_2).to_uncompressed().unwrap();
+    let agg_signature = (sign_1 + sign_2).to_uncompressed().unwrap();
 
     // Verification single signatures
     assert!(

--- a/delegate-cli/src/cli/commands/register.rs
+++ b/delegate-cli/src/cli/commands/register.rs
@@ -37,8 +37,8 @@ impl Register {
             "register_node",
             json!({
                 "multi_addr": self.multi_addr,
-                "bn254_public_key": &bn254_key.public_key.to_compressed()?,
-                "signature": &signature.to_compressed()?,
+                "bn254_public_key": &bn254_key.public_key.to_uncompressed()?,
+                "signature": &signature.to_uncompressed()?,
             })
             .to_string()
             .into_bytes(),

--- a/runtime/core/src/imports.rs
+++ b/runtime/core/src/imports.rs
@@ -354,8 +354,8 @@ pub fn bn254_verify_import_obj(store: &Store, vm_context: VmContext) -> Function
         let public_key: Vec<u8> = public_key.into_iter().map(|wc| wc.get()).collect();
 
         // `bn254` verification
-        let signature_obj = bn254::Signature::from_compressed(signature)?;
-        let public_key_obj = bn254::PublicKey::from_compressed(public_key)?;
+        let signature_obj = bn254::Signature::from_uncompressed(signature)?;
+        let public_key_obj = bn254::PublicKey::from_uncompressed(public_key)?;
 
         Ok(bn254::ECDSA::verify(message, &signature_obj, &public_key_obj)
             .is_ok()
@@ -391,7 +391,7 @@ pub fn bn254_sign_import_obj(store: &Store, vm_context: VmContext) -> Function {
 
         // `bn254` sign
         let signature = bn254::ECDSA::sign(&message, &env.node_config.keypair_bn254.private_key)?;
-        let result = signature.to_compressed()?;
+        let result = signature.to_uncompressed()?;
 
         if result_data_length as usize != result.len() {
             Err(format!(

--- a/runtime/core/src/runtime.rs
+++ b/runtime/core/src/runtime.rs
@@ -137,7 +137,7 @@ impl<HA: HostAdapter> RunnableRuntime for Runtime<HA> {
                             )
                             .env(
                                 "BN254_PUBLIC_KEY",
-                                hex::encode(&self.node_config.keypair_bn254.public_key.to_compressed().unwrap()),
+                                hex::encode(&self.node_config.keypair_bn254.public_key.to_uncompressed().unwrap()),
                             )
                             .args(call_action.args.clone())
                             .stdout(Box::new(stdout_pipe))

--- a/runtime/sdk/src/wasm/bn254.rs
+++ b/runtime/sdk/src/wasm/bn254.rs
@@ -4,9 +4,9 @@ use super::raw;
 
 pub fn bn254_verify(message: &[u8], signature: &Bn254Signature, public_key: &Bn254PublicKey) -> bool {
     let message_len = message.len() as i64;
-    let signature_bytes = signature.to_compressed().expect("Signature should be valid");
+    let signature_bytes = signature.to_uncompressed().expect("Signature should be valid");
     let signature_length = signature_bytes.len() as i64;
-    let public_key_bytes = public_key.to_compressed().expect("Public Key should be valid");
+    let public_key_bytes = public_key.to_uncompressed().expect("Public Key should be valid");
     let public_key_length = public_key_bytes.len() as i64;
 
     let result = unsafe {
@@ -30,11 +30,11 @@ pub fn bn254_verify(message: &[u8], signature: &Bn254Signature, public_key: &Bn2
 pub fn bn254_sign(message: &[u8]) -> Bn254Signature {
     let message_len = message.len() as i64;
 
-    // Compressed Signatures in G1 have a length of 33 bytes
-    let value_len = 33;
+    // Uncompressed Signatures in G1 have a length of 33 bytes
+    let value_len = 64;
     let mut result_data_ptr = vec![0; value_len as usize];
 
     unsafe { raw::bn254_sign(message.as_ptr(), message_len, result_data_ptr.as_mut_ptr(), value_len) };
 
-    Bn254Signature::from_compressed(result_data_ptr).expect("Signature should be valid")
+    Bn254Signature::from_uncompressed(result_data_ptr).expect("Signature should be valid")
 }

--- a/wasm/consensus/src/tasks/batch.rs
+++ b/wasm/consensus/src/tasks/batch.rs
@@ -167,28 +167,29 @@ fn process_batch(
         let mut signature_store = BatchSignatureStore::new(batch.current_slot, batch.clone().merkle_root);
 
         signature_store.aggregated_signature = add_signature(signature_store.aggregated_signature, bn254_signature)
-            .to_compressed()
+            .to_uncompressed()
             .expect("Could not compress Bn254 signature");
 
         signature_store.aggregated_public_keys = add_public_key(
             signature_store.aggregated_public_keys,
-            Bn254PublicKey::from_compressed(bn254_public_key).expect("Could not derive key"),
+            Bn254PublicKey::from_uncompressed(bn254_public_key).expect("Could not derive key"),
         )
-        .to_compressed()
+        .to_uncompressed()
         .expect("Could not compress Bn254 Public Key");
 
         signature_store.signers.push(hex::encode(ed25519_public_key));
 
-        signature_store
-            .signatures
-            .insert(hex::encode(bn254_public_key), bn254_signature.to_compressed().unwrap());
+        signature_store.signatures.insert(
+            hex::encode(bn254_public_key),
+            bn254_signature.to_uncompressed().unwrap(),
+        );
 
         signature_store.slot = batch.current_slot;
 
         let message = Message::Batch(BatchMessage {
             batch_header:       batch.clone().merkle_root,
             bn254_public_key:   bn254_public_key.to_vec(),
-            signature:          bn254_signature.to_compressed().expect("TODO"),
+            signature:          bn254_signature.to_uncompressed().expect("TODO"),
             ed25519_public_key: ed25519_public_key.to_vec(),
         });
         signature_store.p2p_message =
@@ -239,7 +240,7 @@ fn process_slot_leader(batch: &ComputeMerkleRootResult, signature_store: &mut Ba
         last_random_number.to_little_endian(&mut last_random_value_bytes);
 
         let leader_signature_bytes = bn254_sign(&last_random_value_bytes)
-            .to_compressed()
+            .to_uncompressed()
             .expect("Could not compress Bn254 signaturre");
 
         log!(

--- a/wasm/consensus/src/tasks/p2p.rs
+++ b/wasm/consensus/src/tasks/p2p.rs
@@ -43,15 +43,15 @@ impl P2P {
                 // TODO: check that batch was signed by a member of the epoch committee
 
                 // Check valid bn254 signature
-                let bn254_signature = Bn254Signature::from_compressed(&batch_message.signature)
+                let bn254_signature = Bn254Signature::from_uncompressed(&batch_message.signature)
                     .expect("Could not get signature from compressed bytes");
-                let bn254_public_key = Bn254PublicKey::from_compressed(&batch_message.bn254_public_key)
+                let bn254_public_key = Bn254PublicKey::from_uncompressed(&batch_message.bn254_public_key)
                     .expect("Could not get signature from compressed bytes");
 
                 if !bn254_verify(
                     &batch_message.batch_header,
                     &bn254_signature,
-                    &Bn254PublicKey::from_compressed(&batch_message.bn254_public_key).unwrap(),
+                    &Bn254PublicKey::from_uncompressed(&batch_message.bn254_public_key).unwrap(),
                 ) {
                     // TODO: Check if we should disconnect p2p node/slashed/measures
                     log!(
@@ -81,11 +81,11 @@ impl P2P {
 
                     // Aggregate signature and public key
                     let new_aggregate_signature = add_signature(signature_store.aggregated_signature, bn254_signature)
-                        .to_compressed()
+                        .to_uncompressed()
                         .expect("Could not compress Bn254 signature");
                     let new_aggregate_public_key =
                         add_public_key(signature_store.aggregated_public_keys, bn254_public_key)
-                            .to_compressed()
+                            .to_uncompressed()
                             .expect("Could not compress Bn254 Public Key");
                     let ed25519_public_key_str = hex::encode(&batch_message.ed25519_public_key);
 

--- a/wasm/consensus/src/types/batch_signature.rs
+++ b/wasm/consensus/src/types/batch_signature.rs
@@ -64,7 +64,7 @@ pub fn add_signature(aggregated_signature: Vec<u8>, signature: Bn254Signature) -
         return signature;
     }
 
-    Bn254Signature::from_compressed(aggregated_signature).expect("Given Bn254Signature signature is not decodable")
+    Bn254Signature::from_uncompressed(aggregated_signature).expect("Given Bn254Signature signature is not decodable")
         + signature
 }
 
@@ -73,5 +73,6 @@ pub fn add_public_key(aggregated_public_key: Vec<u8>, public_key: Bn254PublicKey
         return public_key;
     }
 
-    Bn254PublicKey::from_compressed(aggregated_public_key).expect("Given Bn254PublicKey is not decodable") + public_key
+    Bn254PublicKey::from_uncompressed(aggregated_public_key).expect("Given Bn254PublicKey is not decodable")
+        + public_key
 }

--- a/wasm/test/promise-wasm-bin/src/main.rs
+++ b/wasm/test/promise-wasm-bin/src/main.rs
@@ -129,12 +129,12 @@ fn bn254_verify_test() {
     // Signature
     let signature_hex = args.get(2).unwrap();
     let signature_bytes = decode_hex(signature_hex).unwrap();
-    let signature = Bn254Signature::from_compressed(signature_bytes).unwrap();
+    let signature = Bn254Signature::from_uncompressed(signature_bytes).unwrap();
 
     // Public key
     let public_key_hex = args.get(3).unwrap();
     let public_key_bytes = decode_hex(public_key_hex).unwrap();
-    let public_key = Bn254PublicKey::from_compressed(public_key_bytes).unwrap();
+    let public_key = Bn254PublicKey::from_uncompressed(public_key_bytes).unwrap();
 
     let result = bn254_verify(&message, &signature, &public_key);
     db_set("bn254_verify_result", &format!("{result}")).start();
@@ -155,7 +155,7 @@ fn bn254_sign_test() {
     let _private_key = Bn254PrivateKey::try_from(private_key_bytes.as_slice()).unwrap();
 
     let result = bn254_sign(&message);
-    let result_hex = encode_hex(&result.to_compressed().unwrap());
+    let result_hex = encode_hex(&result.to_uncompressed().unwrap());
     db_set("bn254_sign_result", &result_hex).start();
 }
 


### PR DESCRIPTION
## Motivation
To avoid back and forth conversions in `bn254_verify()`'s `format_pairing_check_values()`, and to reduce consequent gas costs in `post_signed_batch()`

## Explanation of Changes

Refactors everything to use uncompressed signatures and uncompressed public keys.

## Related PRs and Issues
https://github.com/sedaprotocol/bn254/pull/7


